### PR TITLE
Update locale used for date/time to be the device default

### DIFF
--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -154,15 +154,16 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
                 ?.getInt(getString(R.string.prefs_settings_key_time_format), 0)
         val date = Date()
 
+        val currentLocale = Locale.getDefault()
         val fWatchTime = when(active) {
-            1 -> SimpleDateFormat("H:mm", Locale.ROOT)
-            2 -> SimpleDateFormat("h:mm aa", Locale.ROOT)
+            1 -> SimpleDateFormat("H:mm", currentLocale)
+            2 -> SimpleDateFormat("h:mm aa", currentLocale)
             else -> DateFormat.getTimeInstance(DateFormat.SHORT)
         }
         home_fragment_time.text = fWatchTime.format(date)
 
 
-        val fWatchDate = SimpleDateFormat("EEE, MMM dd", Locale.ROOT)
+        val fWatchDate = SimpleDateFormat("EEE, MMM dd", currentLocale)
         home_fragment_date.text = fWatchDate.format(date)
     }
 


### PR DESCRIPTION
Previously Unlauncher was using `Locale.ROOT` when formatting the date/time on the home screen.  This [caused issues](https://github.com/jkuester/unlauncher/issues/33) with the date display in Android 11.  

This PR updates the date/time display format to use the default locale settings for the device. This fixes the mentioned formatting issue and should better localize the app for global users.

Closes #33 