### PR TITLE
Remove focus from search field on app launch

### DIFF
--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -189,6 +189,7 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
     override fun onAppClicked(app: App) {
         launchApp(app.packageName, app.activityName, app.userSerial)
         app_drawer_edit_text.clearFocus() // dismiss the on-screen keyboard
+        app_drawer_edit_text.clearComposingText()
         home_fragment.transitionToStart()
     }
 

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -188,6 +188,7 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
 
     override fun onAppClicked(app: App) {
         launchApp(app.packageName, app.activityName, app.userSerial)
+        app_drawer_edit_text.clearFocus() // dismiss the on-screen keyboard
         home_fragment.transitionToStart()
     }
 


### PR DESCRIPTION
Bringing up the app drawer gives focus to the search field. This focus is never removed when we launch an app,
causing the keyboard to come up when we return to the main launcher view as described in #38.

Added a call to clearFocus() on the search field in onAppClicked(), removing the focus from the search field
and allowing us to return to the launcher without opening the keyboard as expected.

Closes #38