### PR TITLE
Fixing more keyboard issues

### DIFF
--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -91,11 +91,11 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
                 }
             }
 
-            override fun onTransitionTrigger(p0: MotionLayout?, p1: Int, p2: Boolean, p3: Float) {
+            override fun onTransitionTrigger(motionLayout: MotionLayout?, triggerId: Int, positive: Boolean, progress: Float) {
                 // do nothing
             }
 
-            override fun onTransitionStarted(p0: MotionLayout?, p1: Int, p2: Int) {
+            override fun onTransitionStarted(motionLayout: MotionLayout?, startId: Int, endId: Int) {
                 // do nothing
             }
 

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -1,5 +1,6 @@
 package com.sduduzog.slimlauncher.ui.main
 
+import android.app.Activity
 import android.content.*
 import android.content.pm.LauncherApps
 import android.os.Bundle
@@ -13,6 +14,9 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
+import androidx.constraintlayout.motion.widget.MotionLayout
+import androidx.constraintlayout.motion.widget.MotionLayout.TransitionListener
 import androidx.lifecycle.Observer
 import androidx.navigation.Navigation
 import com.sduduzog.slimlauncher.BuildConfig
@@ -75,6 +79,28 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
         viewModel.addAppViewModel.apps.observe(viewLifecycleOwner, Observer {
             it?.let { apps ->
                 openAppAdapter.setItems(apps)
+            }
+        })
+        home_fragment.setTransitionListener(object : TransitionListener {
+            override fun onTransitionCompleted(motionLayout: MotionLayout?, currentId: Int) {
+                // hide the keyboard and remove focus from the EditText when swiping back up
+                if (currentId == motionLayout?.startState) {
+                    app_drawer_edit_text.clearFocus()
+                    val inputMethodManager = requireContext().getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+                    inputMethodManager.hideSoftInputFromWindow(requireView().windowToken, 0)
+                }
+            }
+
+            override fun onTransitionTrigger(p0: MotionLayout?, p1: Int, p2: Boolean, p3: Float) {
+                // do nothing
+            }
+
+            override fun onTransitionStarted(p0: MotionLayout?, p1: Int, p2: Int) {
+                // do nothing
+            }
+
+            override fun onTransitionChange(motionLayout: MotionLayout?, startId: Int, endId: Int, progress: Float) {
+                // do nothing
             }
         })
     }

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -99,6 +99,7 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
     override fun onStop() {
         super.onStop()
         activity?.unregisterReceiver(receiver)
+        resetAppDrawerEditText()
     }
 
     private fun setEventListeners() {
@@ -188,7 +189,6 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
 
     override fun onAppClicked(app: App) {
         launchApp(app.packageName, app.activityName, app.userSerial)
-        app_drawer_edit_text.clearFocus() // dismiss the on-screen keyboard
         home_fragment.transitionToStart()
     }
 
@@ -204,6 +204,11 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
         } catch (e: Exception) {
             // Do no shit yet
         }
+    }
+
+    private fun resetAppDrawerEditText() {
+        app_drawer_edit_text.setText("")
+        app_drawer_edit_text.clearFocus()
     }
 
     private val onTextChangeListener: TextWatcher = object : TextWatcher {

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -85,7 +85,7 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
             override fun onTransitionCompleted(motionLayout: MotionLayout?, currentId: Int) {
                 // hide the keyboard and remove focus from the EditText when swiping back up
                 if (currentId == motionLayout?.startState) {
-                    app_drawer_edit_text.clearFocus()
+                    resetAppDrawerEditText()
                     val inputMethodManager = requireContext().getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
                     inputMethodManager.hideSoftInputFromWindow(requireView().windowToken, 0)
                 }

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -234,6 +234,7 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
 
     private fun resetAppDrawerEditText() {
         app_drawer_edit_text.clearComposingText()
+        app_drawer_edit_text.setText("")
         app_drawer_edit_text.clearFocus()
     }
 

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -188,6 +188,7 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
 
     override fun onAppClicked(app: App) {
         launchApp(app.packageName, app.activityName, app.userSerial)
+        app_drawer_edit_text.clearFocus() // dismiss the on-screen keyboard
         home_fragment.transitionToStart()
     }
 

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/options/AddAppFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/options/AddAppFragment.kt
@@ -1,5 +1,6 @@
 package com.sduduzog.slimlauncher.ui.options
 
+import android.app.Activity
 import android.content.Context
 import android.content.pm.LauncherApps
 import android.os.Bundle
@@ -10,6 +11,7 @@ import android.text.TextWatcher
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.inputmethod.InputMethodManager
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
 import androidx.navigation.Navigation
@@ -60,6 +62,9 @@ class AddAppFragment : BaseFragment(), OnAppClickedListener {
     override fun onPause() {
         super.onPause()
         add_app_fragment_edit_text?.removeTextChangedListener(onTextChangeListener)
+
+        val inputMethodManager = requireContext().getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+        inputMethodManager.hideSoftInputFromWindow(requireView().windowToken, 0)
     }
 
     private val onTextChangeListener: TextWatcher = object : TextWatcher {

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,47 @@
+<resources>
+    <string name="app_name" translatable="false">Unlauncher</string>
+    <string name="slim_url" translatable="false">https://github.com/jkuester/unlauncher</string>
+    <string name="main_placeholder_clock" translatable="false">00:00</string>
+    <string name="main_placeholder_date" translatable="false">Sat, Apr 20</string>
+
+    <string-array name="themes_array">
+        <item>默认</item>
+        <item>午夜</item>
+        <item>木星</item>
+        <item>水鸭色</item>
+        <item>糖果色</item>
+        <item>粉彩色</item>
+    </string-array>
+
+    <string-array name="time_format_array">
+        <item>跟随系统设置</item>
+        <item>24 小时</item>
+        <item>12 小时</item>
+    </string-array>
+
+    <string name="prefs_settings" translatable="false">设置</string>
+    <string name="prefs_settings_key_theme" translatable="false">key_theme</string>
+    <string name="prefs_settings_key_time_format" translatable="false">time_format</string>
+    <string name="prefs_settings_key_toggle_status_bar" translatable="false">hide_status_bar</string>
+    <string name="choose_time_format_dialog_title">选择时间格式</string>
+    <string name="main_fragment_options">选项</string>
+    <string name="options_fragment_about_slim">关于 Unlauncher</string>
+    <string name="options_fragment_device_settings">设备设置</string>
+    <string name="options_fragment_change_theme">更改主题</string>
+    <string name="options_fragment_choose_time_format">选择时间格式</string>
+    <string name="options_fragment_customise_apps">自定义应用</string>
+    <string name="options_fragment_toggle_status_bar">切换状态栏</string>
+    <string name="options_fragment_hide_status_bar">隐藏状态栏</string>
+    <string name="options_fragment_show_status_bar">显示状态栏</string>
+    <string name="customise_apps_fragment_add">添加</string>
+    <string name="menu_rename">重命名</string>
+    <string name="menu_remove">移除</string>
+    <string name="choose_theme_dialog_title">选择主题</string>
+    <string name="add_apps_fragment_search_apps">搜索应用</string>
+    <string name="customise_apps_fragment_remove_all">移除全部</string>
+    <string name="menu_reset">重置</string>
+    <string name="remove_all_apps_dialog_title" translatable="false">移除所有应用</string>
+    <string name="remove_all_apps_dialog_message" translatable="false">"此操作不会卸载你的应用。"
+    "只是想确认一下你是否有意清除这个列表。"</string>
+
+</resources>


### PR DESCRIPTION
This fixes a few more cases where the keyboard is not being hidden in addition to #40:

* fix the keyboard staying open after swiping down from the app drawer
* fix the keyboard staying open after adding an app to the home screen
* fix all cases of the edit box staying in focus after opening another app in any way (by moving the `clearFocus` call to `onStop`)