### PR TITLE
Support long-press for settings and hiding quick buttons

### DIFF
--- a/app/src/main/java/com/sduduzog/slimlauncher/MainActivity.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/MainActivity.kt
@@ -3,6 +3,10 @@ package com.sduduzog.slimlauncher
 import android.content.SharedPreferences
 import android.content.res.Resources
 import android.os.Bundle
+import android.util.Log
+import android.view.GestureDetector
+import android.view.GestureDetector.SimpleOnGestureListener
+import android.view.MotionEvent
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
@@ -32,6 +36,11 @@ class MainActivity : AppCompatActivity(),
 
     override fun detachSubscriber(s: ISubscriber) {
         subscribers.remove(s as BaseFragment)
+    }
+
+    override fun dispatchTouchEvent(ev: MotionEvent?): Boolean {
+        gestureDetector.onTouchEvent(ev)
+        return super.dispatchTouchEvent(ev)
     }
 
     private fun dispatchBack() {
@@ -138,4 +147,16 @@ class MainActivity : AppCompatActivity(),
     private fun completeBackAction() {
         super.onBackPressed()
     }
+
+    private val gestureDetector = GestureDetector(baseContext, object : SimpleOnGestureListener() {
+        override fun onLongPress(e: MotionEvent) {
+            Log.e("", "Longpress detected")
+
+            // Open Options
+            val homeView = findViewById<View>(R.id.home_fragment)
+            if(homeView != null) {
+                findNavController(homeView).navigate(R.id.action_homeFragment_to_optionsFragment, null)
+            }
+        }
+    })
 }

--- a/app/src/main/java/com/sduduzog/slimlauncher/MainActivity.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/MainActivity.kt
@@ -150,8 +150,6 @@ class MainActivity : AppCompatActivity(),
 
     private val gestureDetector = GestureDetector(baseContext, object : SimpleOnGestureListener() {
         override fun onLongPress(e: MotionEvent) {
-            Log.e("", "Longpress detected")
-
             // Open Options
             val homeView = findViewById<View>(R.id.home_fragment)
             if(homeView != null) {

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/dialogs/ChooseQuickButtonDialog.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/dialogs/ChooseQuickButtonDialog.kt
@@ -1,0 +1,45 @@
+package com.sduduzog.slimlauncher.ui.dialogs
+
+import android.app.AlertDialog
+import android.app.Dialog
+import android.content.Context
+import android.content.DialogInterface
+import android.content.SharedPreferences
+import android.os.Bundle
+import androidx.core.content.edit
+import androidx.fragment.app.DialogFragment
+import com.sduduzog.slimlauncher.R
+
+class ChooseQuickButtonDialog(private var settingsKey: Int, private var defaultIconId: Int) : DialogFragment() {
+    private lateinit var settings: SharedPreferences
+    private var onDismissListener: DialogInterface.OnDismissListener? = null
+    private val iconIdsByIndex = mapOf(0 to defaultIconId, 1 to R.drawable.ic_empty)
+    private val indexesByIconId = iconIdsByIndex.entries.associate { it.value to it.key }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val builder = AlertDialog.Builder(requireContext())
+        settings = requireContext().getSharedPreferences(getString(R.string.prefs_settings), Context.MODE_PRIVATE)
+
+        val currentIconId = settings.getInt(getString(settingsKey), defaultIconId)
+
+        builder.setTitle(R.string.options_fragment_customize_quick_buttons)
+
+        builder.setSingleChoiceItems(R.array.quick_button_array, indexesByIconId[currentIconId]!!) { dialogInterface, i ->
+            dialogInterface.dismiss()
+            settings.edit {
+                putInt(getString(settingsKey), iconIdsByIndex[i]!!)
+            }
+
+        }
+        return builder.create()
+    }
+
+    fun setOnDismissListener(onDismissListener: DialogInterface.OnDismissListener?) {
+        this.onDismissListener = onDismissListener
+    }
+
+    override fun onDismiss(dialog: DialogInterface) {
+        super.onDismiss(dialog)
+        onDismissListener?.onDismiss(dialog)
+    }
+}

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -71,7 +71,6 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
         })
 
         setEventListeners()
-        home_fragment_options.setOnClickListener(Navigation.createNavigateOnClickListener(R.id.action_homeFragment_to_optionsFragment))
 
         // Populate the app drawer
         val openAppAdapter = AddAppAdapter(this)
@@ -152,26 +151,40 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
             }
         }
 
-        home_fragment_call.setOnClickListener { view ->
-            try {
-                val pm = context?.packageManager!!
-                val intent = Intent(Intent.ACTION_DIAL)
-                val componentName = intent.resolveActivity(pm)
-                if (componentName == null) launchActivity(view, intent) else
-                    pm.getLaunchIntentForPackage(componentName.packageName)?.let {
-                        launchActivity(view, it)
-                    } ?: run { launchActivity(view, intent) }
-            } catch (e: Exception) {
-                // Do nothing
+        val leftButtonIcon = getQuickButtonIcon(R.string.prefs_settings_key_quick_button_left_icon_id, R.drawable.ic_call)
+        home_fragment_call.setImageResource(leftButtonIcon)
+        if(leftButtonIcon != R.drawable.ic_empty) {
+            home_fragment_call.setOnClickListener { view ->
+                try {
+                    val pm = context?.packageManager!!
+                    val intent = Intent(Intent.ACTION_DIAL)
+                    val componentName = intent.resolveActivity(pm)
+                    if (componentName == null) launchActivity(view, intent) else
+                        pm.getLaunchIntentForPackage(componentName.packageName)?.let {
+                            launchActivity(view, it)
+                        } ?: run { launchActivity(view, intent) }
+                } catch (e: Exception) {
+                    // Do nothing
+                }
             }
         }
 
-        home_fragment_camera.setOnClickListener {
-            try {
-                val intent = Intent(MediaStore.INTENT_ACTION_STILL_IMAGE_CAMERA)
-                launchActivity(it, intent)
-            } catch (e: Exception) {
-                // Do nothing
+        val centerButtonIcon = getQuickButtonIcon(R.string.prefs_settings_key_quick_button_center_icon_id, R.drawable.ic_cog)
+        home_fragment_options.setImageResource(centerButtonIcon)
+        if(centerButtonIcon != R.drawable.ic_empty) {
+            home_fragment_options.setOnClickListener(Navigation.createNavigateOnClickListener(R.id.action_homeFragment_to_optionsFragment))
+        }
+
+        val rightButtonIcon = getQuickButtonIcon(R.string.prefs_settings_key_quick_button_right_icon_id, R.drawable.ic_photo_camera)
+        home_fragment_camera.setImageResource(rightButtonIcon)
+        if(rightButtonIcon != R.drawable.ic_empty) {
+            home_fragment_camera.setOnClickListener {
+                try {
+                    val intent = Intent(MediaStore.INTENT_ACTION_STILL_IMAGE_CAMERA)
+                    launchActivity(it, intent)
+                } catch (e: Exception) {
+                    // Do nothing
+                }
             }
         }
     }
@@ -236,6 +249,11 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
         app_drawer_edit_text.clearComposingText()
         app_drawer_edit_text.setText("")
         app_drawer_edit_text.clearFocus()
+    }
+
+    private fun getQuickButtonIcon(buttonPrefKey: Int, defaultIconId: Int): Int {
+        return context?.getSharedPreferences(getString(R.string.prefs_settings), Context.MODE_PRIVATE)
+                ?.getInt(getString(buttonPrefKey), defaultIconId) ?: defaultIconId
     }
 
     private val onTextChangeListener: TextWatcher = object : TextWatcher {

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/options/CustomizeQuickButtonsFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/options/CustomizeQuickButtonsFragment.kt
@@ -1,0 +1,62 @@
+package com.sduduzog.slimlauncher.ui.options
+
+import android.content.Context
+import android.content.DialogInterface
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.sduduzog.slimlauncher.R
+import com.sduduzog.slimlauncher.ui.dialogs.ChooseQuickButtonDialog
+import com.sduduzog.slimlauncher.utils.BaseFragment
+import kotlinx.android.synthetic.main.customize_quick_buttons_fragment.*
+
+class CustomizeQuickButtonsFragment : BaseFragment() {
+    override fun getFragmentView(): ViewGroup = customize_quick_buttons_fragment
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.customize_quick_buttons_fragment, container, false)
+    }
+
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+
+        customize_quick_buttons_fragment_left.setOnClickListener {
+            val chooseTimeFormatDialog = ChooseQuickButtonDialog(R.string.prefs_settings_key_quick_button_left_icon_id, R.drawable.ic_call)
+            chooseTimeFormatDialog.setOnDismissListener(DialogInterface.OnDismissListener {
+                setQuickButtonIcons()
+            })
+            chooseTimeFormatDialog.showNow(childFragmentManager, "QUICK_BUTTON_CHOOSER")
+        }
+        customize_quick_buttons_fragment_center.setOnClickListener {
+            val chooseTimeFormatDialog = ChooseQuickButtonDialog(R.string.prefs_settings_key_quick_button_center_icon_id, R.drawable.ic_cog)
+            chooseTimeFormatDialog.setOnDismissListener(DialogInterface.OnDismissListener {
+                setQuickButtonIcons()
+            })
+            chooseTimeFormatDialog.showNow(childFragmentManager, "QUICK_BUTTON_CHOOSER")
+        }
+        customize_quick_buttons_fragment_right.setOnClickListener {
+            val chooseTimeFormatDialog = ChooseQuickButtonDialog(R.string.prefs_settings_key_quick_button_right_icon_id, R.drawable.ic_photo_camera)
+            chooseTimeFormatDialog.setOnDismissListener(DialogInterface.OnDismissListener {
+                setQuickButtonIcons()
+            })
+            chooseTimeFormatDialog.showNow(childFragmentManager, "QUICK_BUTTON_CHOOSER")
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        setQuickButtonIcons()
+    }
+
+    private fun setQuickButtonIcons() {
+        customize_quick_buttons_fragment_left.setImageResource(getIcon(R.string.prefs_settings_key_quick_button_left_icon_id, R.drawable.ic_call))
+        customize_quick_buttons_fragment_center.setImageResource(getIcon(R.string.prefs_settings_key_quick_button_center_icon_id, R.drawable.ic_cog))
+        customize_quick_buttons_fragment_right.setImageResource(getIcon(R.string.prefs_settings_key_quick_button_right_icon_id, R.drawable.ic_photo_camera))
+    }
+
+    private fun getIcon(buttonPrefKey: Int, defaultIconId: Int): Int {
+        return context?.getSharedPreferences(getString(R.string.prefs_settings), Context.MODE_PRIVATE)
+                ?.getInt(getString(buttonPrefKey), defaultIconId) ?: defaultIconId
+    }
+}

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/options/OptionsFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/options/OptionsFragment.kt
@@ -54,5 +54,6 @@ class OptionsFragment : BaseFragment() {
             }
         }
         options_fragment_customise_apps.setOnClickListener(Navigation.createNavigateOnClickListener(R.id.action_optionsFragment_to_customiseAppsFragment))
+        options_fragment_customize_quick_buttons.setOnClickListener(Navigation.createNavigateOnClickListener(R.id.action_optionsFragment_to_customiseQuickButtonsFragment))
     }
 }

--- a/app/src/main/res/drawable/ic_empty.xml
+++ b/app/src/main/res/drawable/ic_empty.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path android:fillColor="#00000000"
+        android:pathData="M0,0 L0,0 L0,0 z" />
+</vector>

--- a/app/src/main/res/layout/customize_quick_buttons_fragment.xml
+++ b/app/src/main/res/layout/customize_quick_buttons_fragment.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/customize_quick_buttons_fragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.options.CustomizeQuickButtonsFragment">
+
+    <TextView
+        android:id="@+id/customize_quick_buttons_fragment_header"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/_16sdp"
+        android:layout_marginTop="@dimen/_8sdp"
+        android:text="@string/options_fragment_customize_quick_buttons"
+        android:textAppearance="@style/TextAppearance.AppCompat"
+        android:textSize="@dimen/_25ssp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/customize_quick_buttons_fragment_left"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/_8sdp"
+        android:layout_marginBottom="@dimen/_8sdp"
+        android:padding="@dimen/_8sdp"
+        android:background="@layout/imageview_border"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:srcCompat="@drawable/ic_call"
+        tools:ignore="ContentDescription" />
+
+    <ImageView
+        android:id="@+id/customize_quick_buttons_fragment_center"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/_8sdp"
+        android:alpha="1"
+        android:padding="@dimen/_8sdp"
+        android:background="@layout/imageview_border"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/customize_quick_buttons_fragment_right"
+        app:layout_constraintStart_toEndOf="@+id/customize_quick_buttons_fragment_left"
+        app:srcCompat="@drawable/ic_cog"
+        tools:ignore="ContentDescription" />
+
+    <ImageView
+        android:id="@+id/customize_quick_buttons_fragment_right"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/_8sdp"
+        android:layout_marginBottom="@dimen/_8sdp"
+        android:padding="@dimen/_8sdp"
+        android:background="@layout/imageview_border"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:srcCompat="@drawable/ic_photo_camera"
+        tools:ignore="ContentDescription" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/imageview_border.xml
+++ b/app/src/main/res/layout/imageview_border.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:layout_height="wrap_content" android:layout_width="wrap_content">
+    <stroke
+        android:width="3dp"
+        android:color="?attr/colorAccent" />
+</shape>

--- a/app/src/main/res/layout/options_fragment.xml
+++ b/app/src/main/res/layout/options_fragment.xml
@@ -93,7 +93,19 @@
         android:text="@string/options_fragment_customise_apps"
         android:textAppearance="@style/TextAppearance.AppCompat"
         android:textSize="@dimen/_20ssp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/options_fragment_customize_quick_buttons"
         app:layout_constraintStart_toStartOf="@+id/options_fragment_toggle_status_bar"
         app:layout_constraintTop_toBottomOf="@+id/options_fragment_toggle_status_bar" />
+
+    <TextView
+        android:id="@+id/options_fragment_customize_quick_buttons"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:layout_marginBottom="32dp"
+        android:text="@string/options_fragment_customize_quick_buttons"
+        android:textAppearance="@style/TextAppearance.AppCompat"
+        android:textSize="@dimen/_20ssp"
+        app:layout_constraintStart_toStartOf="@+id/options_fragment_customise_apps"
+        app:layout_constraintTop_toBottomOf="@+id/options_fragment_customise_apps" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -22,6 +22,9 @@
         <action
             android:id="@+id/action_optionsFragment_to_customiseAppsFragment"
             app:destination="@id/customiseAppsFragment" />
+        <action
+            android:id="@+id/action_optionsFragment_to_customiseQuickButtonsFragment"
+            app:destination="@id/customiseQuickButtonsFragment" />
     </fragment>
     <fragment
         android:id="@+id/customiseAppsFragment"
@@ -37,5 +40,10 @@
         android:name="com.sduduzog.slimlauncher.ui.options.AddAppFragment"
         android:label="add_app_fragment"
         tools:layout="@layout/add_app_fragment" />
+    <fragment
+        android:id="@+id/customiseQuickButtonsFragment"
+        android:name="com.sduduzog.slimlauncher.ui.options.CustomizeQuickButtonsFragment"
+        android:label="customise_quick_buttons_fragment"
+        tools:layout="@layout/customize_quick_buttons_fragment" />
 
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,15 @@
         <item>12 Hour</item>
     </string-array>
 
+    <string-array name="quick_button_array">
+        <item>Show</item>
+        <item>Hide</item>
+    </string-array>
+
     <string name="prefs_settings" translatable="false">settings</string>
+    <string name="prefs_settings_key_quick_button_center_icon_id" translatable="false">quick_button_center</string>
+    <string name="prefs_settings_key_quick_button_left_icon_id" translatable="false">quick_button_left</string>
+    <string name="prefs_settings_key_quick_button_right_icon_id" translatable="false">quick_button_right</string>
     <string name="prefs_settings_key_theme" translatable="false">key_theme</string>
     <string name="prefs_settings_key_time_format" translatable="false">time_format</string>
     <string name="prefs_settings_key_toggle_status_bar" translatable="false">hide_status_bar</string>
@@ -30,6 +38,7 @@
     <string name="options_fragment_change_theme">Change Theme</string>
     <string name="options_fragment_choose_time_format">Choose Time Format</string>
     <string name="options_fragment_customise_apps">Customise Apps</string>
+    <string name="options_fragment_customize_quick_buttons">Customise Quick Buttons</string>
     <string name="options_fragment_toggle_status_bar">Toggle Status Bar</string>
     <string name="options_fragment_hide_status_bar">Hide Status Bar</string>
     <string name="options_fragment_show_status_bar">Show Status Bar</string>


### PR DESCRIPTION
Adds support for accessing the Unlauncher settings by long-pressing anywhere on the home screen.

Also adds support for customizing the visibility of the quick-buttons (with the goal of eventually being able to fully customize these buttons with future updates).

Closes #36 
