### PR TITLE
Moved home search listener from onResume to onActivityCreated

### DIFF
--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -118,7 +118,6 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
 
         viewModel.addAppViewModel.setInstalledApps(getInstalledApps())
         viewModel.addAppViewModel.filterApps("")
-        app_drawer_edit_text.addTextChangedListener(onTextChangeListener)
     }
 
     override fun onStop() {
@@ -187,6 +186,8 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
                 }
             }
         }
+
+        app_drawer_edit_text.addTextChangedListener(onTextChangeListener)
     }
 
     fun updateClock() {


### PR DESCRIPTION
This avoids setting the listener every time onResume is called
which made the search really slow after many searches.