### PR TITLE
Convert Unlauncher preferences to use the Proto DataStore instead of SharedPreferences

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,9 @@
+import com.google.protobuf.gradle.*
+
 plugins {
     id("com.android.application")
     id("dagger.hilt.android.plugin")
+    id("com.google.protobuf") version "0.8.12"
     kotlin("android")
     kotlin("android.extensions")
     kotlin("kapt")
@@ -73,12 +76,16 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("androidx.recyclerview:recyclerview:1.1.0")
     implementation("androidx.constraintlayout:constraintlayout:2.0.1")
+    implementation("androidx.datastore:datastore:1.0.0-rc02")
+    implementation("androidx.datastore:datastore-core:1.0.0-rc02")
+    implementation("com.google.protobuf:protobuf-javalite:3.10.0")
 
     // Arch Components
     implementation("androidx.core:core-ktx:1.5.0-alpha03")
     implementation("androidx.fragment:fragment-ktx:1.2.5")
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
     implementation("androidx.navigation:navigation-fragment-ktx:2.3.0")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.3.0")
     implementation("androidx.room:room-runtime:2.2.5")
     implementation("androidx.lifecycle:lifecycle-common-java8:2.2.0")
     kapt("androidx.room:room-compiler:2.2.5")
@@ -90,4 +97,18 @@ dependencies {
     implementation("androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha02")
     kapt("androidx.hilt:hilt-compiler:1.0.0-alpha02")
     kapt("com.google.dagger:hilt-android-compiler:2.29-alpha")
+}
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.10.0"
+    }
+    generateProtoTasks {
+        all().forEach { task ->
+            task.builtins {
+                id("java") {
+                    option("lite")
+                }
+            }
+        }
+    }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -3,7 +3,7 @@ import com.google.protobuf.gradle.*
 plugins {
     id("com.android.application")
     id("dagger.hilt.android.plugin")
-    id("com.google.protobuf") version "0.8.12"
+    id("com.google.protobuf") version "0.8.17"
     kotlin("android")
     kotlin("android.extensions")
     kotlin("kapt")
@@ -76,8 +76,8 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("androidx.recyclerview:recyclerview:1.1.0")
     implementation("androidx.constraintlayout:constraintlayout:2.0.1")
-    implementation("androidx.datastore:datastore:1.0.0-rc02")
-    implementation("androidx.datastore:datastore-core:1.0.0-rc02")
+    implementation("androidx.datastore:datastore:1.0.0")
+    implementation("androidx.datastore:datastore-core:1.0.0")
     implementation("com.google.protobuf:protobuf-javalite:3.10.0")
 
     // Arch Components
@@ -85,7 +85,7 @@ dependencies {
     implementation("androidx.fragment:fragment-ktx:1.2.5")
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
     implementation("androidx.navigation:navigation-fragment-ktx:2.3.0")
-    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.3.0")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.3.1")
     implementation("androidx.room:room-runtime:2.2.5")
     implementation("androidx.lifecycle:lifecycle-common-java8:2.2.0")
     kapt("androidx.room:room-compiler:2.2.5")
@@ -100,7 +100,7 @@ dependencies {
 }
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.10.0"
+        artifact = "com.google.protobuf:protoc:3.17.3"
     }
     generateProtoTasks {
         all().forEach { task ->

--- a/app/src/main/java/com/sduduzog/slimlauncher/datasource/QuickButtonPreferencesRepository.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/datasource/QuickButtonPreferencesRepository.kt
@@ -2,6 +2,7 @@ package com.sduduzog.slimlauncher.datasource
 
 import android.util.Log
 import androidx.datastore.core.DataStore
+import androidx.lifecycle.LifecycleCoroutineScope
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.asLiveData
 import com.jkuester.unlauncher.datastore.QuickButtonPreferences
@@ -10,10 +11,14 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.transform
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.io.IOException
 
-class QuickButtonPreferencesRepository(private val quickButtonPreferencesStore: DataStore<QuickButtonPreferences>) {
+class QuickButtonPreferencesRepository(
+    private val quickButtonPreferencesStore: DataStore<QuickButtonPreferences>,
+    private val lifecycleScope: LifecycleCoroutineScope
+) {
     companion object {
         const val DEFAULT_ICON_LEFT = R.drawable.ic_call
         const val DEFAULT_ICON_CENTER = R.drawable.ic_cog
@@ -46,31 +51,39 @@ class QuickButtonPreferencesRepository(private val quickButtonPreferencesStore: 
         }
     }
 
-    suspend fun updateLeftIconId(iconId: Int) {
-        quickButtonPreferencesStore.updateData { currentPreferences ->
-            currentPreferences.toBuilder()
-                .setLeftButton(currentPreferences.leftButton.toBuilder().setIconId(iconId).build())
-                .build()
+    fun updateLeftIconId(iconId: Int) {
+        lifecycleScope.launch {
+            quickButtonPreferencesStore.updateData { currentPreferences ->
+                currentPreferences.toBuilder()
+                    .setLeftButton(
+                        currentPreferences.leftButton.toBuilder().setIconId(iconId).build()
+                    )
+                    .build()
+            }
         }
     }
 
-    suspend fun updateCenterIconId(iconId: Int) {
-        quickButtonPreferencesStore.updateData { currentPreferences ->
-            currentPreferences.toBuilder()
-                .setCenterButton(
-                    currentPreferences.centerButton.toBuilder().setIconId(iconId).build()
-                )
-                .build()
+    fun updateCenterIconId(iconId: Int) {
+        lifecycleScope.launch {
+            quickButtonPreferencesStore.updateData { currentPreferences ->
+                currentPreferences.toBuilder()
+                    .setCenterButton(
+                        currentPreferences.centerButton.toBuilder().setIconId(iconId).build()
+                    )
+                    .build()
+            }
         }
     }
 
-    suspend fun updateRightIconId(iconId: Int) {
-        quickButtonPreferencesStore.updateData { currentPreferences ->
-            currentPreferences.toBuilder()
-                .setRightButton(
-                    currentPreferences.rightButton.toBuilder().setIconId(iconId).build()
-                )
-                .build()
+    fun updateRightIconId(iconId: Int) {
+        lifecycleScope.launch {
+            quickButtonPreferencesStore.updateData { currentPreferences ->
+                currentPreferences.toBuilder()
+                    .setRightButton(
+                        currentPreferences.rightButton.toBuilder().setIconId(iconId).build()
+                    )
+                    .build()
+            }
         }
     }
 

--- a/app/src/main/java/com/sduduzog/slimlauncher/datasource/QuickButtonPreferencesRepository.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/datasource/QuickButtonPreferencesRepository.kt
@@ -48,33 +48,49 @@ class QuickButtonPreferencesRepository(private val quickButtonPreferencesStore: 
 
     suspend fun updateLeftIconId(iconId: Int) {
         quickButtonPreferencesStore.updateData { currentPreferences ->
-            currentPreferences.toBuilder().setLeftIconId(iconId).build()
+            currentPreferences.toBuilder()
+                .setLeftButton(currentPreferences.leftButton.toBuilder().setIconId(iconId).build())
+                .build()
         }
     }
 
     suspend fun updateCenterIconId(iconId: Int) {
         quickButtonPreferencesStore.updateData { currentPreferences ->
-            currentPreferences.toBuilder().setCenterIconId(iconId).build()
+            currentPreferences.toBuilder()
+                .setCenterButton(
+                    currentPreferences.centerButton.toBuilder().setIconId(iconId).build()
+                )
+                .build()
         }
     }
 
     suspend fun updateRightIconId(iconId: Int) {
         quickButtonPreferencesStore.updateData { currentPreferences ->
-            currentPreferences.toBuilder().setRightIconId(iconId).build()
+            currentPreferences.toBuilder()
+                .setRightButton(
+                    currentPreferences.rightButton.toBuilder().setIconId(iconId).build()
+                )
+                .build()
         }
     }
 
     private fun validateQuickButtonPreferences(prefs: QuickButtonPreferences): QuickButtonPreferences {
-        if (prefs.leftIconId == 0 || prefs.centerIconId == 0 || prefs.rightIconId == 0) {
+        if (!prefs.hasLeftButton() || !prefs.hasCenterButton() || !prefs.hasRightButton()) {
             val prefBuilder = prefs.toBuilder()
-            if (prefs.leftIconId == 0) {
-                prefBuilder.leftIconId = DEFAULT_ICON_LEFT
+            if (!prefs.hasLeftButton()) {
+                prefBuilder.leftButton =
+                    QuickButtonPreferences.QuickButton.newBuilder().setIconId(DEFAULT_ICON_LEFT)
+                        .build()
             }
-            if (prefs.centerIconId == 0) {
-                prefBuilder.centerIconId = DEFAULT_ICON_CENTER
+            if (!prefs.hasCenterButton()) {
+                prefBuilder.centerButton =
+                    QuickButtonPreferences.QuickButton.newBuilder().setIconId(DEFAULT_ICON_CENTER)
+                        .build()
             }
-            if (prefs.rightIconId == 0) {
-                prefBuilder.rightIconId = DEFAULT_ICON_RIGHT
+            if (!prefs.hasRightButton()) {
+                prefBuilder.rightButton =
+                    QuickButtonPreferences.QuickButton.newBuilder().setIconId(DEFAULT_ICON_RIGHT)
+                        .build()
             }
             return prefBuilder.build()
         }

--- a/app/src/main/java/com/sduduzog/slimlauncher/datasource/QuickButtonPreferencesRepository.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/datasource/QuickButtonPreferencesRepository.kt
@@ -1,0 +1,83 @@
+package com.sduduzog.slimlauncher.datasource
+
+import android.util.Log
+import androidx.datastore.core.DataStore
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.asLiveData
+import com.jkuester.unlauncher.datastore.QuickButtonPreferences
+import com.sduduzog.slimlauncher.R
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.transform
+import kotlinx.coroutines.runBlocking
+import java.io.IOException
+
+class QuickButtonPreferencesRepository(private val quickButtonPreferencesStore: DataStore<QuickButtonPreferences>) {
+    companion object {
+        const val DEFAULT_ICON_LEFT = R.drawable.ic_call
+        const val DEFAULT_ICON_CENTER = R.drawable.ic_cog
+        const val DEFAULT_ICON_RIGHT = R.drawable.ic_photo_camera
+    }
+
+    private val quickButtonPreferencesFlow: Flow<QuickButtonPreferences> =
+        quickButtonPreferencesStore.data
+            .catch { exception ->
+                if (exception is IOException) {
+                    Log.e(
+                        "QuickButtonPrefRepo",
+                        "Error reading quick button preferences.",
+                        exception
+                    )
+                    emit(QuickButtonPreferences.getDefaultInstance())
+                } else {
+                    throw exception
+                }
+            }
+            .transform { prefs -> emit(validateQuickButtonPreferences(prefs)) }
+
+    fun liveData(): LiveData<QuickButtonPreferences> {
+        return quickButtonPreferencesFlow.asLiveData()
+    }
+
+    fun get(): QuickButtonPreferences {
+        return runBlocking {
+            quickButtonPreferencesFlow.first()
+        }
+    }
+
+    suspend fun updateLeftIconId(iconId: Int) {
+        quickButtonPreferencesStore.updateData { currentPreferences ->
+            currentPreferences.toBuilder().setLeftIconId(iconId).build()
+        }
+    }
+
+    suspend fun updateCenterIconId(iconId: Int) {
+        quickButtonPreferencesStore.updateData { currentPreferences ->
+            currentPreferences.toBuilder().setCenterIconId(iconId).build()
+        }
+    }
+
+    suspend fun updateRightIconId(iconId: Int) {
+        quickButtonPreferencesStore.updateData { currentPreferences ->
+            currentPreferences.toBuilder().setRightIconId(iconId).build()
+        }
+    }
+
+    private fun validateQuickButtonPreferences(prefs: QuickButtonPreferences): QuickButtonPreferences {
+        if (prefs.leftIconId == 0 || prefs.centerIconId == 0 || prefs.rightIconId == 0) {
+            val prefBuilder = prefs.toBuilder()
+            if (prefs.leftIconId == 0) {
+                prefBuilder.leftIconId = DEFAULT_ICON_LEFT
+            }
+            if (prefs.centerIconId == 0) {
+                prefBuilder.centerIconId = DEFAULT_ICON_CENTER
+            }
+            if (prefs.rightIconId == 0) {
+                prefBuilder.rightIconId = DEFAULT_ICON_RIGHT
+            }
+            return prefBuilder.build()
+        }
+        return prefs
+    }
+}

--- a/app/src/main/java/com/sduduzog/slimlauncher/datasource/QuickButtonPreferencesSerializer.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/datasource/QuickButtonPreferencesSerializer.kt
@@ -1,0 +1,28 @@
+package com.sduduzog.slimlauncher.datasource
+
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.Serializer
+import com.google.protobuf.InvalidProtocolBufferException
+import com.jkuester.unlauncher.datastore.QuickButtonPreferences
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * Serializer for the [QuickButtonPreferences] object defined in unlauncher_data.proto.
+ */
+object QuickButtonPreferencesSerializer : Serializer<QuickButtonPreferences> {
+    override val defaultValue: QuickButtonPreferences = QuickButtonPreferences.getDefaultInstance()
+
+    @Suppress("BlockingMethodInNonBlockingContext")
+    override suspend fun readFrom(input: InputStream): QuickButtonPreferences {
+        try {
+            return QuickButtonPreferences.parseFrom(input)
+        } catch (exception: InvalidProtocolBufferException) {
+            throw CorruptionException("Cannot read proto.", exception)
+        }
+    }
+
+    @Suppress("BlockingMethodInNonBlockingContext")
+    override suspend fun writeTo(t: QuickButtonPreferences, output: OutputStream) =
+        t.writeTo(output)
+}

--- a/app/src/main/java/com/sduduzog/slimlauncher/datasource/UnlauncherDataSource.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/datasource/UnlauncherDataSource.kt
@@ -1,0 +1,41 @@
+package com.sduduzog.slimlauncher.datasource
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.dataStore
+import androidx.datastore.migrations.SharedPreferencesMigration
+import androidx.datastore.migrations.SharedPreferencesView
+import com.jkuester.unlauncher.datastore.QuickButtonPreferences
+
+private val Context.quickButtonPreferencesStore: DataStore<QuickButtonPreferences> by dataStore(
+    fileName = "unlauncher_data.pb",
+    serializer = QuickButtonPreferencesSerializer,
+    produceMigrations = { context ->
+        listOf(
+            SharedPreferencesMigration(
+                context,
+                "settings"
+            ) { sharedPrefs: SharedPreferencesView, currentData: QuickButtonPreferences ->
+                val prefBuilder = currentData.toBuilder()
+                prefBuilder.leftIconId = sharedPrefs.getInt(
+                    "quick_button_left",
+                    QuickButtonPreferencesRepository.DEFAULT_ICON_LEFT
+                )
+                prefBuilder.centerIconId = sharedPrefs.getInt(
+                    "quick_button_center",
+                    QuickButtonPreferencesRepository.DEFAULT_ICON_CENTER
+                )
+                prefBuilder.rightIconId = sharedPrefs.getInt(
+                    "quick_button_right",
+                    QuickButtonPreferencesRepository.DEFAULT_ICON_RIGHT
+                )
+                prefBuilder.build()
+            }
+        )
+    }
+)
+
+class UnlauncherDataSource(context: Context) {
+    val quickButtonPreferencesRepo =
+        QuickButtonPreferencesRepository(context.quickButtonPreferencesStore)
+}

--- a/app/src/main/java/com/sduduzog/slimlauncher/datasource/UnlauncherDataSource.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/datasource/UnlauncherDataSource.kt
@@ -18,23 +18,33 @@ private val Context.quickButtonPreferencesStore: DataStore<QuickButtonPreference
                 setOf("quick_button_left", "quick_button_center", "quick_button_right")
             ) { sharedPrefs: SharedPreferencesView, currentData: QuickButtonPreferences ->
                 val prefBuilder = currentData.toBuilder()
-                if (currentData.leftIconId == 0) {
-                    prefBuilder.leftIconId = sharedPrefs.getInt(
-                        "quick_button_left",
-                        QuickButtonPreferencesRepository.DEFAULT_ICON_LEFT
-                    )
+                if (!currentData.hasLeftButton()) {
+                    prefBuilder.leftButton =
+                        QuickButtonPreferences.QuickButton.newBuilder().setIconId(
+                            sharedPrefs.getInt(
+                                "quick_button_left",
+                                QuickButtonPreferencesRepository.DEFAULT_ICON_LEFT
+                            )
+                        ).build()
                 }
-                if (currentData.centerIconId == 0) {
-                    prefBuilder.centerIconId = sharedPrefs.getInt(
-                        "quick_button_center",
-                        QuickButtonPreferencesRepository.DEFAULT_ICON_CENTER
-                    )
+
+                if (!currentData.hasCenterButton()) {
+                    prefBuilder.centerButton =
+                        QuickButtonPreferences.QuickButton.newBuilder().setIconId(
+                            sharedPrefs.getInt(
+                                "quick_button_center",
+                                QuickButtonPreferencesRepository.DEFAULT_ICON_CENTER
+                            )
+                        ).build()
                 }
-                if (currentData.rightIconId == 0) {
-                    prefBuilder.rightIconId = sharedPrefs.getInt(
-                        "quick_button_right",
-                        QuickButtonPreferencesRepository.DEFAULT_ICON_RIGHT
-                    )
+                if (!currentData.hasRightButton()) {
+                    prefBuilder.rightButton =
+                        QuickButtonPreferences.QuickButton.newBuilder().setIconId(
+                            sharedPrefs.getInt(
+                                "quick_button_right",
+                                QuickButtonPreferencesRepository.DEFAULT_ICON_RIGHT
+                            )
+                        ).build()
                 }
                 prefBuilder.build()
             }

--- a/app/src/main/java/com/sduduzog/slimlauncher/datasource/UnlauncherDataSource.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/datasource/UnlauncherDataSource.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.dataStore
 import androidx.datastore.migrations.SharedPreferencesMigration
 import androidx.datastore.migrations.SharedPreferencesView
+import androidx.lifecycle.LifecycleCoroutineScope
 import com.jkuester.unlauncher.datastore.QuickButtonPreferences
 
 private val Context.quickButtonPreferencesStore: DataStore<QuickButtonPreferences> by dataStore(
@@ -52,7 +53,7 @@ private val Context.quickButtonPreferencesStore: DataStore<QuickButtonPreference
     }
 )
 
-class UnlauncherDataSource(context: Context) {
+class UnlauncherDataSource(context: Context, lifecycleScope: LifecycleCoroutineScope) {
     val quickButtonPreferencesRepo =
-        QuickButtonPreferencesRepository(context.quickButtonPreferencesStore)
+        QuickButtonPreferencesRepository(context.quickButtonPreferencesStore, lifecycleScope)
 }

--- a/app/src/main/java/com/sduduzog/slimlauncher/datasource/UnlauncherDataSource.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/datasource/UnlauncherDataSource.kt
@@ -14,21 +14,28 @@ private val Context.quickButtonPreferencesStore: DataStore<QuickButtonPreference
         listOf(
             SharedPreferencesMigration(
                 context,
-                "settings"
+                "settings",
+                setOf("quick_button_left", "quick_button_center", "quick_button_right")
             ) { sharedPrefs: SharedPreferencesView, currentData: QuickButtonPreferences ->
                 val prefBuilder = currentData.toBuilder()
-                prefBuilder.leftIconId = sharedPrefs.getInt(
-                    "quick_button_left",
-                    QuickButtonPreferencesRepository.DEFAULT_ICON_LEFT
-                )
-                prefBuilder.centerIconId = sharedPrefs.getInt(
-                    "quick_button_center",
-                    QuickButtonPreferencesRepository.DEFAULT_ICON_CENTER
-                )
-                prefBuilder.rightIconId = sharedPrefs.getInt(
-                    "quick_button_right",
-                    QuickButtonPreferencesRepository.DEFAULT_ICON_RIGHT
-                )
+                if (currentData.leftIconId == 0) {
+                    prefBuilder.leftIconId = sharedPrefs.getInt(
+                        "quick_button_left",
+                        QuickButtonPreferencesRepository.DEFAULT_ICON_LEFT
+                    )
+                }
+                if (currentData.centerIconId == 0) {
+                    prefBuilder.centerIconId = sharedPrefs.getInt(
+                        "quick_button_center",
+                        QuickButtonPreferencesRepository.DEFAULT_ICON_CENTER
+                    )
+                }
+                if (currentData.rightIconId == 0) {
+                    prefBuilder.rightIconId = sharedPrefs.getInt(
+                        "quick_button_right",
+                        QuickButtonPreferencesRepository.DEFAULT_ICON_RIGHT
+                    )
+                }
                 prefBuilder.build()
             }
         )

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/dialogs/ChooseQuickButtonDialog.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/dialogs/ChooseQuickButtonDialog.kt
@@ -26,11 +26,11 @@ class ChooseQuickButtonDialog(
         var currentIconId = 0
         when (defaultIconId) {
             QuickButtonPreferencesRepository.DEFAULT_ICON_LEFT -> currentIconId =
-                quickButtonPrefs.leftIconId
+                quickButtonPrefs.leftButton.iconId
             QuickButtonPreferencesRepository.DEFAULT_ICON_CENTER -> currentIconId =
-                quickButtonPrefs.centerIconId
+                quickButtonPrefs.centerButton.iconId
             QuickButtonPreferencesRepository.DEFAULT_ICON_RIGHT -> currentIconId =
-                quickButtonPrefs.rightIconId
+                quickButtonPrefs.rightButton.iconId
         }
 
         builder.setTitle(R.string.options_fragment_customize_quick_buttons)

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/dialogs/ChooseQuickButtonDialog.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/dialogs/ChooseQuickButtonDialog.kt
@@ -2,9 +2,7 @@ package com.sduduzog.slimlauncher.ui.dialogs
 
 import android.app.AlertDialog
 import android.app.Dialog
-import android.content.Context
 import android.content.DialogInterface
-import android.content.SharedPreferences
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.LifecycleCoroutineScope
@@ -15,29 +13,23 @@ import kotlinx.coroutines.launch
 class ChooseQuickButtonDialog(
     private val lifecycleScope: LifecycleCoroutineScope,
     private val repo: QuickButtonPreferencesRepository,
-    private var settingsKey: Int,
-    defaultIconId: Int
+    private val defaultIconId: Int
 ) : DialogFragment() {
-    private lateinit var settings: SharedPreferences
     private var onDismissListener: DialogInterface.OnDismissListener? = null
     private val iconIdsByIndex = mapOf(0 to defaultIconId, 1 to R.drawable.ic_empty)
     private val indexesByIconId = iconIdsByIndex.entries.associate { it.value to it.key }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val builder = AlertDialog.Builder(requireContext())
-        settings = requireContext().getSharedPreferences(
-            getString(R.string.prefs_settings),
-            Context.MODE_PRIVATE
-        )
 
         val quickButtonPrefs = repo.get()
         var currentIconId = 0
-        when (settingsKey) {
-            R.string.prefs_settings_key_quick_button_left_icon_id -> currentIconId =
+        when (defaultIconId) {
+            QuickButtonPreferencesRepository.DEFAULT_ICON_LEFT -> currentIconId =
                 quickButtonPrefs.leftIconId
-            R.string.prefs_settings_key_quick_button_center_icon_id -> currentIconId =
+            QuickButtonPreferencesRepository.DEFAULT_ICON_CENTER -> currentIconId =
                 quickButtonPrefs.centerIconId
-            R.string.prefs_settings_key_quick_button_right_icon_id -> currentIconId =
+            QuickButtonPreferencesRepository.DEFAULT_ICON_RIGHT -> currentIconId =
                 quickButtonPrefs.rightIconId
         }
 
@@ -49,14 +41,14 @@ class ChooseQuickButtonDialog(
         ) { dialogInterface, i ->
             dialogInterface.dismiss()
             lifecycleScope.launch {
-                when (settingsKey) {
-                    R.string.prefs_settings_key_quick_button_left_icon_id -> repo.updateLeftIconId(
+                when (defaultIconId) {
+                    QuickButtonPreferencesRepository.DEFAULT_ICON_LEFT -> repo.updateLeftIconId(
                         iconIdsByIndex[i]!!
                     )
-                    R.string.prefs_settings_key_quick_button_center_icon_id -> repo.updateCenterIconId(
+                    QuickButtonPreferencesRepository.DEFAULT_ICON_CENTER -> repo.updateCenterIconId(
                         iconIdsByIndex[i]!!
                     )
-                    R.string.prefs_settings_key_quick_button_right_icon_id -> repo.updateRightIconId(
+                    QuickButtonPreferencesRepository.DEFAULT_ICON_RIGHT -> repo.updateRightIconId(
                         iconIdsByIndex[i]!!
                     )
                 }

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/dialogs/ChooseQuickButtonDialog.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/dialogs/ChooseQuickButtonDialog.kt
@@ -5,13 +5,10 @@ import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
 import androidx.fragment.app.DialogFragment
-import androidx.lifecycle.LifecycleCoroutineScope
 import com.sduduzog.slimlauncher.R
 import com.sduduzog.slimlauncher.datasource.QuickButtonPreferencesRepository
-import kotlinx.coroutines.launch
 
 class ChooseQuickButtonDialog(
-    private val lifecycleScope: LifecycleCoroutineScope,
     private val repo: QuickButtonPreferencesRepository,
     private val defaultIconId: Int
 ) : DialogFragment() {
@@ -40,18 +37,16 @@ class ChooseQuickButtonDialog(
             indexesByIconId[currentIconId]!!
         ) { dialogInterface, i ->
             dialogInterface.dismiss()
-            lifecycleScope.launch {
-                when (defaultIconId) {
-                    QuickButtonPreferencesRepository.DEFAULT_ICON_LEFT -> repo.updateLeftIconId(
-                        iconIdsByIndex[i]!!
-                    )
-                    QuickButtonPreferencesRepository.DEFAULT_ICON_CENTER -> repo.updateCenterIconId(
-                        iconIdsByIndex[i]!!
-                    )
-                    QuickButtonPreferencesRepository.DEFAULT_ICON_RIGHT -> repo.updateRightIconId(
-                        iconIdsByIndex[i]!!
-                    )
-                }
+            when (defaultIconId) {
+                QuickButtonPreferencesRepository.DEFAULT_ICON_LEFT -> repo.updateLeftIconId(
+                    iconIdsByIndex[i]!!
+                )
+                QuickButtonPreferencesRepository.DEFAULT_ICON_CENTER -> repo.updateCenterIconId(
+                    iconIdsByIndex[i]!!
+                )
+                QuickButtonPreferencesRepository.DEFAULT_ICON_RIGHT -> repo.updateRightIconId(
+                    iconIdsByIndex[i]!!
+                )
             }
         }
         return builder.create()

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -141,44 +141,49 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
             }
         }
 
-        getUnlauncherDataSource().quickButtonPreferencesRepo.liveData().observe(viewLifecycleOwner, { prefs ->
-            val leftButtonIcon = prefs.leftIconId
-            home_fragment_call.setImageResource(leftButtonIcon)
-            if(leftButtonIcon != R.drawable.ic_empty) {
-                home_fragment_call.setOnClickListener { view ->
-                    try {
-                        val pm = context?.packageManager!!
-                        val intent = Intent(Intent.ACTION_DIAL)
-                        val componentName = intent.resolveActivity(pm)
-                        if (componentName == null) launchActivity(view, intent) else
-                            pm.getLaunchIntentForPackage(componentName.packageName)?.let {
-                                launchActivity(view, it)
-                            } ?: run { launchActivity(view, intent) }
-                    } catch (e: Exception) {
-                        // Do nothing
+        getUnlauncherDataSource().quickButtonPreferencesRepo.liveData()
+            .observe(viewLifecycleOwner, { prefs ->
+                val leftButtonIcon = prefs.leftButton.iconId
+                home_fragment_call.setImageResource(leftButtonIcon)
+                if (leftButtonIcon != R.drawable.ic_empty) {
+                    home_fragment_call.setOnClickListener { view ->
+                        try {
+                            val pm = context?.packageManager!!
+                            val intent = Intent(Intent.ACTION_DIAL)
+                            val componentName = intent.resolveActivity(pm)
+                            if (componentName == null) launchActivity(view, intent) else
+                                pm.getLaunchIntentForPackage(componentName.packageName)?.let {
+                                    launchActivity(view, it)
+                                } ?: run { launchActivity(view, intent) }
+                        } catch (e: Exception) {
+                            // Do nothing
+                        }
                     }
                 }
-            }
 
-            val centerButtonIcon = prefs.centerIconId
-            home_fragment_options.setImageResource(centerButtonIcon)
-            if(centerButtonIcon != R.drawable.ic_empty) {
-                home_fragment_options.setOnClickListener(Navigation.createNavigateOnClickListener(R.id.action_homeFragment_to_optionsFragment))
-            }
+                val centerButtonIcon = prefs.centerButton.iconId
+                home_fragment_options.setImageResource(centerButtonIcon)
+                if (centerButtonIcon != R.drawable.ic_empty) {
+                    home_fragment_options.setOnClickListener(
+                        Navigation.createNavigateOnClickListener(
+                            R.id.action_homeFragment_to_optionsFragment
+                        )
+                    )
+                }
 
-            val rightButtonIcon = prefs.rightIconId
-            home_fragment_camera.setImageResource(rightButtonIcon)
-            if(rightButtonIcon != R.drawable.ic_empty) {
-                home_fragment_camera.setOnClickListener {
-                    try {
-                        val intent = Intent(MediaStore.INTENT_ACTION_STILL_IMAGE_CAMERA)
-                        launchActivity(it, intent)
-                    } catch (e: Exception) {
-                        // Do nothing
+                val rightButtonIcon = prefs.rightButton.iconId
+                home_fragment_camera.setImageResource(rightButtonIcon)
+                if (rightButtonIcon != R.drawable.ic_empty) {
+                    home_fragment_camera.setOnClickListener {
+                        try {
+                            val intent = Intent(MediaStore.INTENT_ACTION_STILL_IMAGE_CAMERA)
+                            launchActivity(it, intent)
+                        } catch (e: Exception) {
+                            // Do nothing
+                        }
                     }
                 }
-            }
-        })
+            })
 
         app_drawer_edit_text.addTextChangedListener(onTextChangeListener)
     }

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -141,42 +141,44 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
             }
         }
 
-        val leftButtonIcon = getQuickButtonIcon(R.string.prefs_settings_key_quick_button_left_icon_id, R.drawable.ic_call)
-        home_fragment_call.setImageResource(leftButtonIcon)
-        if(leftButtonIcon != R.drawable.ic_empty) {
-            home_fragment_call.setOnClickListener { view ->
-                try {
-                    val pm = context?.packageManager!!
-                    val intent = Intent(Intent.ACTION_DIAL)
-                    val componentName = intent.resolveActivity(pm)
-                    if (componentName == null) launchActivity(view, intent) else
-                        pm.getLaunchIntentForPackage(componentName.packageName)?.let {
-                            launchActivity(view, it)
-                        } ?: run { launchActivity(view, intent) }
-                } catch (e: Exception) {
-                    // Do nothing
+        getUnlauncherDataSource().quickButtonPreferencesRepo.liveData().observe(viewLifecycleOwner, { prefs ->
+            val leftButtonIcon = prefs.leftIconId
+            home_fragment_call.setImageResource(leftButtonIcon)
+            if(leftButtonIcon != R.drawable.ic_empty) {
+                home_fragment_call.setOnClickListener { view ->
+                    try {
+                        val pm = context?.packageManager!!
+                        val intent = Intent(Intent.ACTION_DIAL)
+                        val componentName = intent.resolveActivity(pm)
+                        if (componentName == null) launchActivity(view, intent) else
+                            pm.getLaunchIntentForPackage(componentName.packageName)?.let {
+                                launchActivity(view, it)
+                            } ?: run { launchActivity(view, intent) }
+                    } catch (e: Exception) {
+                        // Do nothing
+                    }
                 }
             }
-        }
 
-        val centerButtonIcon = getQuickButtonIcon(R.string.prefs_settings_key_quick_button_center_icon_id, R.drawable.ic_cog)
-        home_fragment_options.setImageResource(centerButtonIcon)
-        if(centerButtonIcon != R.drawable.ic_empty) {
-            home_fragment_options.setOnClickListener(Navigation.createNavigateOnClickListener(R.id.action_homeFragment_to_optionsFragment))
-        }
+            val centerButtonIcon = prefs.centerIconId
+            home_fragment_options.setImageResource(centerButtonIcon)
+            if(centerButtonIcon != R.drawable.ic_empty) {
+                home_fragment_options.setOnClickListener(Navigation.createNavigateOnClickListener(R.id.action_homeFragment_to_optionsFragment))
+            }
 
-        val rightButtonIcon = getQuickButtonIcon(R.string.prefs_settings_key_quick_button_right_icon_id, R.drawable.ic_photo_camera)
-        home_fragment_camera.setImageResource(rightButtonIcon)
-        if(rightButtonIcon != R.drawable.ic_empty) {
-            home_fragment_camera.setOnClickListener {
-                try {
-                    val intent = Intent(MediaStore.INTENT_ACTION_STILL_IMAGE_CAMERA)
-                    launchActivity(it, intent)
-                } catch (e: Exception) {
-                    // Do nothing
+            val rightButtonIcon = prefs.rightIconId
+            home_fragment_camera.setImageResource(rightButtonIcon)
+            if(rightButtonIcon != R.drawable.ic_empty) {
+                home_fragment_camera.setOnClickListener {
+                    try {
+                        val intent = Intent(MediaStore.INTENT_ACTION_STILL_IMAGE_CAMERA)
+                        launchActivity(it, intent)
+                    } catch (e: Exception) {
+                        // Do nothing
+                    }
                 }
             }
-        }
+        })
 
         app_drawer_edit_text.addTextChangedListener(onTextChangeListener)
     }
@@ -241,11 +243,6 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
         app_drawer_edit_text.clearComposingText()
         app_drawer_edit_text.setText("")
         app_drawer_edit_text.clearFocus()
-    }
-
-    private fun getQuickButtonIcon(buttonPrefKey: Int, defaultIconId: Int): Int {
-        return context?.getSharedPreferences(getString(R.string.prefs_settings), Context.MODE_PRIVATE)
-                ?.getInt(getString(buttonPrefKey), defaultIconId) ?: defaultIconId
     }
 
     private val onTextChangeListener: TextWatcher = object : TextWatcher {

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/options/CustomizeQuickButtonsFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/options/CustomizeQuickButtonsFragment.kt
@@ -28,9 +28,9 @@ class CustomizeQuickButtonsFragment : BaseFragment() {
         val prefsRepo = getUnlauncherDataSource().quickButtonPreferencesRepo
 
         prefsRepo.liveData().observe(viewLifecycleOwner, { prefs ->
-            customize_quick_buttons_fragment_left.setImageResource(prefs.leftIconId)
-            customize_quick_buttons_fragment_center.setImageResource(prefs.centerIconId)
-            customize_quick_buttons_fragment_right.setImageResource(prefs.rightIconId)
+            customize_quick_buttons_fragment_left.setImageResource(prefs.leftButton.iconId)
+            customize_quick_buttons_fragment_center.setImageResource(prefs.centerButton.iconId)
+            customize_quick_buttons_fragment_right.setImageResource(prefs.rightButton.iconId)
         })
 
         customize_quick_buttons_fragment_left.setOnClickListener {

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/options/CustomizeQuickButtonsFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/options/CustomizeQuickButtonsFragment.kt
@@ -1,12 +1,12 @@
 package com.sduduzog.slimlauncher.ui.options
 
-import android.content.Context
-import android.content.DialogInterface
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.lifecycle.lifecycleScope
 import com.sduduzog.slimlauncher.R
+import com.sduduzog.slimlauncher.datasource.QuickButtonPreferencesRepository
 import com.sduduzog.slimlauncher.ui.dialogs.ChooseQuickButtonDialog
 import com.sduduzog.slimlauncher.utils.BaseFragment
 import kotlinx.android.synthetic.main.customize_quick_buttons_fragment.*
@@ -14,49 +14,48 @@ import kotlinx.android.synthetic.main.customize_quick_buttons_fragment.*
 class CustomizeQuickButtonsFragment : BaseFragment() {
     override fun getFragmentView(): ViewGroup = customize_quick_buttons_fragment
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
         return inflater.inflate(R.layout.customize_quick_buttons_fragment, container, false)
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
 
+        val prefsRepo = getUnlauncherDataSource().quickButtonPreferencesRepo
+
+        prefsRepo.liveData().observe(viewLifecycleOwner, { prefs ->
+            customize_quick_buttons_fragment_left.setImageResource(prefs.leftIconId)
+            customize_quick_buttons_fragment_center.setImageResource(prefs.centerIconId)
+            customize_quick_buttons_fragment_right.setImageResource(prefs.rightIconId)
+        })
+
         customize_quick_buttons_fragment_left.setOnClickListener {
-            val chooseTimeFormatDialog = ChooseQuickButtonDialog(R.string.prefs_settings_key_quick_button_left_icon_id, R.drawable.ic_call)
-            chooseTimeFormatDialog.setOnDismissListener(DialogInterface.OnDismissListener {
-                setQuickButtonIcons()
-            })
-            chooseTimeFormatDialog.showNow(childFragmentManager, "QUICK_BUTTON_CHOOSER")
+            ChooseQuickButtonDialog(
+                viewLifecycleOwner.lifecycleScope,
+                prefsRepo,
+                R.string.prefs_settings_key_quick_button_left_icon_id,
+                QuickButtonPreferencesRepository.DEFAULT_ICON_LEFT
+            ).showNow(childFragmentManager, "QUICK_BUTTON_CHOOSER")
         }
         customize_quick_buttons_fragment_center.setOnClickListener {
-            val chooseTimeFormatDialog = ChooseQuickButtonDialog(R.string.prefs_settings_key_quick_button_center_icon_id, R.drawable.ic_cog)
-            chooseTimeFormatDialog.setOnDismissListener(DialogInterface.OnDismissListener {
-                setQuickButtonIcons()
-            })
-            chooseTimeFormatDialog.showNow(childFragmentManager, "QUICK_BUTTON_CHOOSER")
+            ChooseQuickButtonDialog(
+                viewLifecycleOwner.lifecycleScope,
+                prefsRepo,
+                R.string.prefs_settings_key_quick_button_center_icon_id,
+                QuickButtonPreferencesRepository.DEFAULT_ICON_CENTER
+            ).showNow(childFragmentManager, "QUICK_BUTTON_CHOOSER")
         }
         customize_quick_buttons_fragment_right.setOnClickListener {
-            val chooseTimeFormatDialog = ChooseQuickButtonDialog(R.string.prefs_settings_key_quick_button_right_icon_id, R.drawable.ic_photo_camera)
-            chooseTimeFormatDialog.setOnDismissListener(DialogInterface.OnDismissListener {
-                setQuickButtonIcons()
-            })
-            chooseTimeFormatDialog.showNow(childFragmentManager, "QUICK_BUTTON_CHOOSER")
+            ChooseQuickButtonDialog(
+                viewLifecycleOwner.lifecycleScope,
+                prefsRepo,
+                R.string.prefs_settings_key_quick_button_right_icon_id,
+                QuickButtonPreferencesRepository.DEFAULT_ICON_RIGHT
+            ).showNow(childFragmentManager, "QUICK_BUTTON_CHOOSER")
         }
-    }
-
-    override fun onResume() {
-        super.onResume()
-        setQuickButtonIcons()
-    }
-
-    private fun setQuickButtonIcons() {
-        customize_quick_buttons_fragment_left.setImageResource(getIcon(R.string.prefs_settings_key_quick_button_left_icon_id, R.drawable.ic_call))
-        customize_quick_buttons_fragment_center.setImageResource(getIcon(R.string.prefs_settings_key_quick_button_center_icon_id, R.drawable.ic_cog))
-        customize_quick_buttons_fragment_right.setImageResource(getIcon(R.string.prefs_settings_key_quick_button_right_icon_id, R.drawable.ic_photo_camera))
-    }
-
-    private fun getIcon(buttonPrefKey: Int, defaultIconId: Int): Int {
-        return context?.getSharedPreferences(getString(R.string.prefs_settings), Context.MODE_PRIVATE)
-                ?.getInt(getString(buttonPrefKey), defaultIconId) ?: defaultIconId
     }
 }

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/options/CustomizeQuickButtonsFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/options/CustomizeQuickButtonsFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.lifecycle.lifecycleScope
 import com.sduduzog.slimlauncher.R
 import com.sduduzog.slimlauncher.datasource.QuickButtonPreferencesRepository
 import com.sduduzog.slimlauncher.ui.dialogs.ChooseQuickButtonDialog
@@ -35,21 +34,18 @@ class CustomizeQuickButtonsFragment : BaseFragment() {
 
         customize_quick_buttons_fragment_left.setOnClickListener {
             ChooseQuickButtonDialog(
-                viewLifecycleOwner.lifecycleScope,
                 prefsRepo,
                 QuickButtonPreferencesRepository.DEFAULT_ICON_LEFT
             ).showNow(childFragmentManager, "QUICK_BUTTON_CHOOSER")
         }
         customize_quick_buttons_fragment_center.setOnClickListener {
             ChooseQuickButtonDialog(
-                viewLifecycleOwner.lifecycleScope,
                 prefsRepo,
                 QuickButtonPreferencesRepository.DEFAULT_ICON_CENTER
             ).showNow(childFragmentManager, "QUICK_BUTTON_CHOOSER")
         }
         customize_quick_buttons_fragment_right.setOnClickListener {
             ChooseQuickButtonDialog(
-                viewLifecycleOwner.lifecycleScope,
                 prefsRepo,
                 QuickButtonPreferencesRepository.DEFAULT_ICON_RIGHT
             ).showNow(childFragmentManager, "QUICK_BUTTON_CHOOSER")

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/options/CustomizeQuickButtonsFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/options/CustomizeQuickButtonsFragment.kt
@@ -37,7 +37,6 @@ class CustomizeQuickButtonsFragment : BaseFragment() {
             ChooseQuickButtonDialog(
                 viewLifecycleOwner.lifecycleScope,
                 prefsRepo,
-                R.string.prefs_settings_key_quick_button_left_icon_id,
                 QuickButtonPreferencesRepository.DEFAULT_ICON_LEFT
             ).showNow(childFragmentManager, "QUICK_BUTTON_CHOOSER")
         }
@@ -45,7 +44,6 @@ class CustomizeQuickButtonsFragment : BaseFragment() {
             ChooseQuickButtonDialog(
                 viewLifecycleOwner.lifecycleScope,
                 prefsRepo,
-                R.string.prefs_settings_key_quick_button_center_icon_id,
                 QuickButtonPreferencesRepository.DEFAULT_ICON_CENTER
             ).showNow(childFragmentManager, "QUICK_BUTTON_CHOOSER")
         }
@@ -53,7 +51,6 @@ class CustomizeQuickButtonsFragment : BaseFragment() {
             ChooseQuickButtonDialog(
                 viewLifecycleOwner.lifecycleScope,
                 prefsRepo,
-                R.string.prefs_settings_key_quick_button_right_icon_id,
                 QuickButtonPreferencesRepository.DEFAULT_ICON_RIGHT
             ).showNow(childFragmentManager, "QUICK_BUTTON_CHOOSER")
         }

--- a/app/src/main/java/com/sduduzog/slimlauncher/utils/BaseFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/utils/BaseFragment.kt
@@ -13,11 +13,12 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityOptionsCompat
 import androidx.fragment.app.Fragment
 import com.sduduzog.slimlauncher.BuildConfig
-import com.sduduzog.slimlauncher.MainActivity
 import com.sduduzog.slimlauncher.R
 import com.sduduzog.slimlauncher.data.model.App
+import com.sduduzog.slimlauncher.datasource.UnlauncherDataSource
 
 abstract class BaseFragment : Fragment(), ISubscriber {
+    private lateinit var unlauncherDataSource: UnlauncherDataSource
 
     abstract fun getFragmentView(): ViewGroup
 
@@ -97,5 +98,12 @@ abstract class BaseFragment : Fragment(), ISubscriber {
         val filter = mutableListOf<String>()
         filter.add(BuildConfig.APPLICATION_ID)
         return list.filterNot { filter.contains(it.packageName) }
+    }
+
+    protected fun getUnlauncherDataSource(): UnlauncherDataSource {
+        if(!::unlauncherDataSource.isInitialized) {
+            unlauncherDataSource = UnlauncherDataSource(requireContext())
+        }
+        return unlauncherDataSource
     }
 }

--- a/app/src/main/java/com/sduduzog/slimlauncher/utils/BaseFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/utils/BaseFragment.kt
@@ -12,6 +12,7 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityOptionsCompat
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import com.sduduzog.slimlauncher.BuildConfig
 import com.sduduzog.slimlauncher.R
 import com.sduduzog.slimlauncher.data.model.App
@@ -101,8 +102,9 @@ abstract class BaseFragment : Fragment(), ISubscriber {
     }
 
     protected fun getUnlauncherDataSource(): UnlauncherDataSource {
-        if(!::unlauncherDataSource.isInitialized) {
-            unlauncherDataSource = UnlauncherDataSource(requireContext())
+        if (!::unlauncherDataSource.isInitialized) {
+            unlauncherDataSource =
+                UnlauncherDataSource(requireContext(), viewLifecycleOwner.lifecycleScope)
         }
         return unlauncherDataSource
     }

--- a/app/src/main/proto/unlauncher_data.proto
+++ b/app/src/main/proto/unlauncher_data.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+option java_package = "com.jkuester.unlauncher.datastore";
+option java_multiple_files = true;
+
+message QuickButtonPreferences {
+  int32 left_icon_id = 1;
+  int32 center_icon_id = 2;
+  int32 right_icon_id = 3;
+}

--- a/app/src/main/proto/unlauncher_data.proto
+++ b/app/src/main/proto/unlauncher_data.proto
@@ -4,7 +4,10 @@ option java_package = "com.jkuester.unlauncher.datastore";
 option java_multiple_files = true;
 
 message QuickButtonPreferences {
-  int32 left_icon_id = 1;
-  int32 center_icon_id = 2;
-  int32 right_icon_id = 3;
+  message QuickButton {
+    int32 icon_id = 1;
+  }
+  QuickButton left_button = 1;
+  QuickButton center_button = 2;
+  QuickButton right_button = 3;
 }

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -25,9 +25,6 @@
     </string-array>
 
     <string name="prefs_settings" translatable="false">settings</string>
-    <string name="prefs_settings_key_quick_button_center_icon_id" translatable="false">quick_button_center</string>
-    <string name="prefs_settings_key_quick_button_left_icon_id" translatable="false">quick_button_left</string>
-    <string name="prefs_settings_key_quick_button_right_icon_id" translatable="false">quick_button_right</string>
     <string name="prefs_settings_key_theme" translatable="false">key_theme</string>
     <string name="prefs_settings_key_time_format" translatable="false">time_format</string>
     <string name="prefs_settings_key_toggle_status_bar" translatable="false">hide_status_bar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,9 +28,6 @@
     </string-array>
 
     <string name="prefs_settings" translatable="false">settings</string>
-    <string name="prefs_settings_key_quick_button_center_icon_id" translatable="false">quick_button_center</string>
-    <string name="prefs_settings_key_quick_button_left_icon_id" translatable="false">quick_button_left</string>
-    <string name="prefs_settings_key_quick_button_right_icon_id" translatable="false">quick_button_right</string>
     <string name="prefs_settings_key_theme" translatable="false">key_theme</string>
     <string name="prefs_settings_key_time_format" translatable="false">time_format</string>
     <string name="prefs_settings_key_toggle_status_bar" translatable="false">hide_status_bar</string>


### PR DESCRIPTION
The Proto DataStore has a few benefits over the existing code that was using SharedPreferences. You can store more complex strongly typed data than just a bunch of key-value pairs.  But at the same time, you do not have to deal with the extra overhead of a "real" database/ORM.  

My hope is to be able to expand the Unlauncher data model in the future using this as the pattern.  