### PR TITLE
Move slow things to background to improve performance on slower phones

### DIFF
--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -88,9 +88,6 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
         super.onResume()
         updateClock()
 
-        lifecycleScope.launch {
-            getUnlauncherDataSource().unlauncherAppsRepo.setApps(getInstalledApps())
-        }
         if (!::appDrawerAdapter.isInitialized) {
             appDrawerAdapter.setAppFilter()
         }
@@ -99,6 +96,11 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
     override fun onStop() {
         super.onStop()
         activity?.unregisterReceiver(receiver)
+
+        lifecycleScope.launch {
+            getUnlauncherDataSource().unlauncherAppsRepo.setApps(getInstalledApps())
+        }
+
         resetAppDrawerEditText()
     }
 


### PR DESCRIPTION
On my phone this action takes times, typically 1-2 seconds. Moving it to `onStop()` which executed when the app is in background could improve performance.

However, it may cause some delay (because lifecycle) for app showing in drawer, but there's already some delay in my experience, so that's maybe not very important. This could be discussed.