### PR TITLE
Load the installed apps in IO thread on resume

### DIFF
--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -27,6 +27,7 @@ import com.sduduzog.slimlauncher.utils.BaseFragment
 import com.sduduzog.slimlauncher.utils.OnLaunchAppListener
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.android.synthetic.main.home_fragment.*
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.text.DateFormat
 import java.text.SimpleDateFormat
@@ -88,7 +89,7 @@ class HomeFragment(private val viewModel: MainViewModel) : BaseFragment(), OnLau
         super.onResume()
         updateClock()
 
-        lifecycleScope.launch {
+        lifecycleScope.launch(Dispatchers.IO) {
             getUnlauncherDataSource().unlauncherAppsRepo.setApps(getInstalledApps())
         }
         if (!::appDrawerAdapter.isInitialized) {


### PR DESCRIPTION
I believe this is a proper and permanent fix for the performance issues mentioned in #72.  Basically, we want to check which apps are currently installed on the device when Unlauncher resumes since that is how the contents of the app drawer are kept up to date (I don't know of any kind of `LiveData` style stream that we could subscribe to for those changes....).  However, on some devices that check takes several seconds (probably depends on devices resources and the number of apps installed). 

This PR updates the code for checking the currently installed apps to do it in a background IO thread Instead of blocking the UI thread for the check. This lets the app load immediately while any changes to the installed apps will be reflected in the drawer as soon as the info finishes loading.  This seems like an acceptable trade-off since it is unlikely that large numbers of apps will be frequently added/removed.

Closes #72