### PR TITLE
Ignore case when sorting apps in drawer

### DIFF
--- a/app/src/main/java/com/sduduzog/slimlauncher/datasource/UnlauncherDataSource.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/datasource/UnlauncherDataSource.kt
@@ -1,6 +1,7 @@
 package com.sduduzog.slimlauncher.datasource
 
 import android.content.Context
+import androidx.datastore.core.DataMigration
 import androidx.datastore.core.DataStore
 import androidx.datastore.dataStore
 import androidx.datastore.migrations.SharedPreferencesMigration
@@ -8,6 +9,7 @@ import androidx.datastore.migrations.SharedPreferencesView
 import androidx.lifecycle.LifecycleCoroutineScope
 import com.jkuester.unlauncher.datastore.QuickButtonPreferences
 import com.jkuester.unlauncher.datastore.UnlauncherApps
+import com.sduduzog.slimlauncher.datasource.apps.UnlauncherAppsMigrations
 import com.sduduzog.slimlauncher.datasource.apps.UnlauncherAppsRepository
 import com.sduduzog.slimlauncher.datasource.apps.UnlauncherAppsSerializer
 import com.sduduzog.slimlauncher.datasource.quickbuttonprefs.QuickButtonPreferencesRepository
@@ -60,7 +62,8 @@ private val Context.quickButtonPreferencesStore: DataStore<QuickButtonPreference
 
 private val Context.unlauncherAppsStore: DataStore<UnlauncherApps> by dataStore(
     fileName = "unlauncher_apps.proto",
-    serializer = UnlauncherAppsSerializer
+    serializer = UnlauncherAppsSerializer,
+    produceMigrations = { context -> UnlauncherAppsMigrations().get(context) }
 )
 
 class UnlauncherDataSource(context: Context, lifecycleScope: LifecycleCoroutineScope) {

--- a/app/src/main/java/com/sduduzog/slimlauncher/datasource/apps/UnlauncherAppsMigrations.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/datasource/apps/UnlauncherAppsMigrations.kt
@@ -1,0 +1,32 @@
+package com.sduduzog.slimlauncher.datasource.apps
+
+import android.content.Context
+import androidx.datastore.core.DataMigration
+import com.jkuester.unlauncher.datastore.UnlauncherApps
+
+class UnlauncherAppsMigrations {
+
+    fun get(context: Context): List<DataMigration<UnlauncherApps>> {
+        return listOf(object : UnlauncherAppsMigration(1) {
+            // Re-sort the apps with new alphabetizing scheme
+            override suspend fun migrate(currentData: UnlauncherApps): UnlauncherApps {
+                val builder = currentData.toBuilder()
+                sortAppsAlphabetically(builder)
+                return updateVersion(builder)
+            }
+        })
+    }
+
+    abstract class UnlauncherAppsMigration(private val version: Int) :
+        DataMigration<UnlauncherApps> {
+        override suspend fun shouldMigrate(currentData: UnlauncherApps): Boolean {
+            return currentData.version < version;
+        }
+
+        override suspend fun cleanUp() {}
+
+        fun updateVersion(builder: UnlauncherApps.Builder): UnlauncherApps {
+            return builder.setVersion(version).build();
+        }
+    }
+}

--- a/app/src/main/java/com/sduduzog/slimlauncher/datasource/apps/UnlauncherAppsRepository.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/datasource/apps/UnlauncherAppsRepository.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 import java.io.IOException
+import java.util.*
 
 class UnlauncherAppsRepository(
     private val unlauncherAppsStore: DataStore<UnlauncherApps>,
@@ -49,7 +50,11 @@ class UnlauncherAppsRepository(
                 ) == null
             }.forEach { app ->
                 val index =
-                    unlauncherAppsBuilder.appsList.indexOfFirst { unlauncherApp -> unlauncherApp.displayName > app.appName }
+                    unlauncherAppsBuilder.appsList.indexOfFirst { unlauncherApp ->
+                        unlauncherApp.displayName.toUpperCase(
+                            Locale.getDefault()
+                        ) > app.appName.toUpperCase(Locale.getDefault())
+                    }
                 unlauncherAppsBuilder.addApps(
                     if (index >= 0) index else unlauncherAppsBuilder.appsList.size,
                     UnlauncherApp.newBuilder().setPackageName(app.packageName)

--- a/app/src/main/java/com/sduduzog/slimlauncher/datasource/apps/UnlauncherAppsRepository.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/datasource/apps/UnlauncherAppsRepository.kt
@@ -49,14 +49,7 @@ class UnlauncherAppsRepository(
                     app.activityName
                 ) == null
             }.forEach { app ->
-                val index =
-                    unlauncherAppsBuilder.appsList.indexOfFirst { unlauncherApp ->
-                        unlauncherApp.displayName.toUpperCase(
-                            Locale.getDefault()
-                        ) > app.appName.toUpperCase(Locale.getDefault())
-                    }
                 unlauncherAppsBuilder.addApps(
-                    if (index >= 0) index else unlauncherAppsBuilder.appsList.size,
                     UnlauncherApp.newBuilder().setPackageName(app.packageName)
                         .setClassName(app.activityName).setUserSerial(app.userSerial)
                         .setDisplayName(app.appName).setDisplayInDrawer(true)
@@ -75,6 +68,7 @@ class UnlauncherAppsRepository(
                 )
             }
 
+            sortAppsAlphabetically(unlauncherAppsBuilder)
             unlauncherAppsBuilder.build()
         }
     }
@@ -131,7 +125,10 @@ class UnlauncherAppsRepository(
                 val builder = currentApps.toBuilder()
                 val index = builder.appsList.indexOf(appToUpdate)
                 if (index >= 0) {
-                    builder.setApps(index, appToUpdate.toBuilder().setDisplayInDrawer(displayInDrawer))
+                    builder.setApps(
+                        index,
+                        appToUpdate.toBuilder().setDisplayInDrawer(displayInDrawer)
+                    )
                 }
                 builder.build()
             }
@@ -147,4 +144,11 @@ class UnlauncherAppsRepository(
             packageName == app.packageName && className == app.className
         }
     }
+}
+
+fun sortAppsAlphabetically(unlauncherAppsBuilder: UnlauncherApps.Builder) {
+    val sortedApps =
+        unlauncherAppsBuilder.appsList.sortedBy { it.displayName.toUpperCase(Locale.getDefault()) }
+    unlauncherAppsBuilder.clearApps()
+    unlauncherAppsBuilder.addAllApps(sortedApps)
 }

--- a/app/src/main/proto/unlauncher_apps.proto
+++ b/app/src/main/proto/unlauncher_apps.proto
@@ -14,4 +14,5 @@ message UnlauncherApp {
 
 message UnlauncherApps {
   repeated UnlauncherApp apps = 1;
+  int32 version = 2;
 }


### PR DESCRIPTION
Updates the alphabetization code for sorting apps in the drawer to ignore case.

Also adds the `version` property to `unlauncher_apps` data to allow for cleanly migrating data.


Closes #90 