### PR TITLE
Expand status bar on swipe down

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
     <uses-permission android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
+    <uses-permission android:name="android.permission.EXPAND_STATUS_BAR" />
 
 
     <application

--- a/app/src/main/java/com/sduduzog/slimlauncher/MainActivity.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.sduduzog.slimlauncher
 
+import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import android.content.res.Resources
 import android.os.Bundle
@@ -8,6 +9,7 @@ import android.view.GestureDetector.SimpleOnGestureListener
 import android.view.MotionEvent
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.constraintlayout.motion.widget.MotionLayout
 import androidx.navigation.NavController
 import androidx.navigation.Navigation.findNavController
 import com.sduduzog.slimlauncher.di.MainFragmentFactoryEntryPoint
@@ -17,6 +19,8 @@ import com.sduduzog.slimlauncher.utils.IPublisher
 import com.sduduzog.slimlauncher.utils.ISubscriber
 import dagger.hilt.android.AndroidEntryPoint
 import dagger.hilt.android.EntryPointAccessors
+import java.lang.reflect.Method
+import kotlin.math.absoluteValue
 
 
 @AndroidEntryPoint
@@ -155,5 +159,31 @@ class MainActivity : AppCompatActivity(),
                 findNavController(homeView).navigate(R.id.action_homeFragment_to_optionsFragment, null)
             }
         }
+
+        override fun onFling(
+            e1: MotionEvent,
+            e2: MotionEvent,
+            velocityX: Float,
+            velocityY: Float
+        ): Boolean {
+            val homeView = findViewById<MotionLayout>(R.id.home_fragment)
+            if (homeView != null) {
+                val homeScreen = homeView.constraintSetIds[0]
+                val isFlingFromHomeScreen = homeView.currentState == homeScreen
+                val isFlingDown = velocityY > 0 && velocityY > velocityX.absoluteValue
+                if (isFlingDown && isFlingFromHomeScreen) {
+                    expandStatusBar()
+                }
+            }
+            return super.onFling(e1, e2, velocityX, velocityY)
+        }
     })
+
+    @SuppressLint("WrongConstant")  // statusbar is an internal API
+    private fun expandStatusBar() {
+        val service = getSystemService("statusbar")
+        val statusbarManager = Class.forName("android.app.StatusBarManager")
+        val expand: Method = statusbarManager.getMethod("expandNotificationsPanel")
+        expand.invoke(service)
+    }
 }

--- a/app/src/main/java/com/sduduzog/slimlauncher/MainActivity.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/MainActivity.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import android.content.SharedPreferences
 import android.content.res.Resources
 import android.os.Bundle
+import android.util.Log
 import android.view.GestureDetector
 import android.view.GestureDetector.SimpleOnGestureListener
 import android.view.MotionEvent
@@ -181,9 +182,22 @@ class MainActivity : AppCompatActivity(),
 
     @SuppressLint("WrongConstant")  // statusbar is an internal API
     private fun expandStatusBar() {
-        val service = getSystemService("statusbar")
-        val statusbarManager = Class.forName("android.app.StatusBarManager")
-        val expand: Method = statusbarManager.getMethod("expandNotificationsPanel")
-        expand.invoke(service)
+        try {
+            getSystemService("statusbar")?.let { service ->
+                val statusbarManager = Class.forName("android.app.StatusBarManager")
+                val expand: Method = statusbarManager.getMethod("expandNotificationsPanel")
+                expand.invoke(service)
+            }
+        } catch (e: Exception) {
+            // Do nothing. There does not seem to be any official way with the Android SKD to open the status bar.
+            // https://stackoverflow.com/questions/5029354/how-can-i-programmatically-open-close-notifications-in-android
+            // This hack may break on future versions of Android (or even just not work for specific manufacturer variants).
+            // So, if anything goes wrong, we will just do nothing.
+            Log.e(
+                "MainActivity",
+                "Error trying to expand the notifications panel.",
+                e
+            )
+        }
     }
 }


### PR DESCRIPTION
Resolving #30 and scratching my own itches.

I've never used MotionLayout before, so hope I used the _right_ properties here. They do the job though.

As for the status bar extension, that seems to be _the way_ to do this. I haven't found this documented in the Android docs and it's a recurring theme in all related SO questions (e.g. [here](https://stackoverflow.com/a/14320900)). As the min SDK version here is 21, I went for `expandNotificationsPanel` directly.

<details>
<summary>Demo gif</summary>

![pulldown-navigation-bar](https://user-images.githubusercontent.com/11031002/174037645-bdbce3d7-e7fd-49c7-a3ad-aade5b6558a0.gif)

</details>

Closes #30