### PR TITLE
Add Italian localization

### DIFF
--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,0 +1,41 @@
+<resources>
+    <string-array name="themes_array">
+        <item>Predefinito</item>
+        <item>Notturno</item>
+        <item>Giove</item>
+        <item>Bluastro</item>
+        <item>Caramella</item>
+        <item>Pastello</item>
+    </string-array>
+
+    <string-array name="time_format_array">
+        <item>Come impostato nel dispositivo</item>
+        <item>24 ore</item>
+        <item>12 ore</item>
+    </string-array>
+
+    <string-array name="quick_button_array">
+        <item>Mostra</item>
+        <item>Nascondi</item>
+    </string-array>
+
+    <string name="choose_time_format_dialog_title">Formato dell\'ora</string>
+    <string name="main_fragment_options">Impostazioni</string>
+    <string name="options_fragment_about_slim">Informazioni su Unlauncher</string>
+    <string name="options_fragment_device_settings">Impostazioni del dispositivo</string>
+    <string name="options_fragment_change_theme">Cambia il tema</string>
+    <string name="options_fragment_choose_time_format">Formato dell\'ora</string>
+    <string name="options_fragment_customise_apps">Applicazioni preferite</string>
+    <string name="options_fragment_toggle_status_bar">Mostra/nascondi barra di stato</string>
+    <string name="options_fragment_hide_status_bar">Nascondi la barra di stato</string>
+    <string name="options_fragment_show_status_bar">Mostra la barra di stato</string>
+    <string name="customise_apps_fragment_add">Aggiungi</string>
+    <string name="menu_rename">Rinomina</string>
+    <string name="menu_remove">Rimuovi</string>
+    <string name="choose_theme_dialog_title">Scegli il tema</string>
+    <string name="add_apps_fragment_search_apps">Cerca applicazioni</string>
+    <string name="customise_apps_fragment_remove_all">Rimuovi tutto</string>
+    <string name="menu_reset">Azzera modifiche</string>
+    <string name="options_fragment_customize_quick_buttons">Pulsanti rapidi</string>
+    <string name="options_fragment_customize_app_drawer">Elenco applicazioni</string>
+</resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -6,6 +6,7 @@
         <item>Bluastro</item>
         <item>Caramella</item>
         <item>Pastello</item>
+        <item>Mezzogiorno</item>
     </string-array>
 
     <string-array name="time_format_array">


### PR DESCRIPTION
Hello,
I'm trying to add Italian localization and I translated the available strings.

It seems there are some strings that are marked as "untranslatable" in the source file.
The string `remove_all_apps_dialog_title` is an example of this. Should such cases be translated too?

Anyway, I tried compiling and running Unlauncher on my phone, the localization seems to work :)

Hope it helps!