### PR TITLE
Adapts `navigationBarColor` based on theme

### DIFF
--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -8,6 +8,7 @@
         <item name="android:colorBackground">@color/primaryColor</item>
         <item name="android:colorForeground">@color/accentColor</item>
         <item name="android:fontFamily">@font/ubuntu</item>
+        <item name="android:navigationBarColor">@color/primaryColor</item>
     </style>
 
 

--- a/app/src/main/res/values-notnight/styles.xml
+++ b/app/src/main/res/values-notnight/styles.xml
@@ -7,5 +7,6 @@
         <item name="colorPrimary">@color/primaryColor</item>
         <item name="colorPrimaryDark">@color/primaryColorDark</item>
         <item name="android:colorBackground">@color/primaryColor</item>
+        <item name="android:navigationBarColor">@color/primaryColor</item>
     </style>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -7,6 +7,7 @@
         <item name="colorPrimary">@color/lightPrimaryColor</item>
         <item name="colorPrimaryDark">@color/primaryColorDark</item>
         <item name="android:colorBackground">@color/lightPrimaryColor</item>
+        <item name="android:navigationBarColor">@color/lightPrimaryColor</item>
         <item name="android:fontFamily">@font/ubuntu</item>
     </style>
 
@@ -16,6 +17,7 @@
         <item name="colorPrimaryDark">@color/darkPrimaryColor</item>
         <item name="android:colorBackground">@color/darkPrimaryColor</item>
         <item name="android:colorForeground">@color/darkAccentColor</item>
+        <item name="android:navigationBarColor">@color/darkPrimaryColor</item>
         <item name="android:fontFamily">@font/ubuntu</item>
     </style>
 
@@ -23,23 +25,27 @@
         <item name="colorPrimary">@color/colorBlueGrey</item>
         <item name="colorPrimaryDark">@color/colorBlueGrey</item>
         <item name="android:colorBackground">@color/colorBlueGrey</item>
+        <item name="android:navigationBarColor">@color/colorBlueGrey</item>
     </style>
 
     <style name="AppCandyTheme" parent="AppThemeDark">
         <item name="colorPrimary">@color/colorCandy</item>
         <item name="colorPrimaryDark">@color/colorCandy</item>
         <item name="android:colorBackground">@color/colorCandy</item>
+        <item name="android:navigationBarColor">@color/colorCandy</item>
     </style>
 
     <style name="AppPinkTheme" parent="AppThemeLight">
         <item name="colorPrimary">@color/colorPink</item>
         <item name="colorPrimaryDark">@color/colorPink</item>
         <item name="android:colorBackground">@color/colorPink</item>
+        <item name="android:navigationBarColor">@color/colorPink</item>
     </style>
 
     <style name="AppTealTheme" parent="AppThemeLight">
         <item name="colorPrimary">@color/colorTeal</item>
         <item name="colorPrimaryDark">@color/colorTeal</item>
         <item name="android:colorBackground">@color/colorTeal</item>
+        <item name="android:navigationBarColor">@color/colorTeal</item>
     </style>
 </resources>


### PR DESCRIPTION
This PR fixes #131 .

<img src="https://user-images.githubusercontent.com/3295340/194087450-156fe602-12e2-4ebe-8055-88593281cbdd.png" height="300px" />
<img src="https://user-images.githubusercontent.com/3295340/194087871-30b9ffa9-d466-4ec6-bbe3-80b76a7860e9.png" height="300px" />



@jkuester I am not sure if this should go into the upcoming release, as it is more of an improvement rather than a bugfix. What do you think?