### PR TITLE
Fix quick button preferences to not break when app is updated

### DIFF
--- a/app/src/main/java/com/sduduzog/slimlauncher/datasource/UnlauncherDataSource.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/datasource/UnlauncherDataSource.kt
@@ -3,8 +3,6 @@ package com.sduduzog.slimlauncher.datasource
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.dataStore
-import androidx.datastore.migrations.SharedPreferencesMigration
-import androidx.datastore.migrations.SharedPreferencesView
 import androidx.lifecycle.LifecycleCoroutineScope
 import com.jkuester.unlauncher.datastore.CorePreferences
 import com.jkuester.unlauncher.datastore.QuickButtonPreferences
@@ -14,52 +12,14 @@ import com.sduduzog.slimlauncher.datasource.apps.UnlauncherAppsRepository
 import com.sduduzog.slimlauncher.datasource.apps.UnlauncherAppsSerializer
 import com.sduduzog.slimlauncher.datasource.coreprefs.CorePreferencesRepository
 import com.sduduzog.slimlauncher.datasource.coreprefs.CorePreferencesSerializer
+import com.sduduzog.slimlauncher.datasource.quickbuttonprefs.QuickButtonPreferencesMigrations
 import com.sduduzog.slimlauncher.datasource.quickbuttonprefs.QuickButtonPreferencesRepository
 import com.sduduzog.slimlauncher.datasource.quickbuttonprefs.QuickButtonPreferencesSerializer
 
 private val Context.quickButtonPreferencesStore: DataStore<QuickButtonPreferences> by dataStore(
     fileName = "quick_button_preferences.proto",
     serializer = QuickButtonPreferencesSerializer,
-    produceMigrations = { context ->
-        listOf(
-            SharedPreferencesMigration(
-                context,
-                "settings",
-                setOf("quick_button_left", "quick_button_center", "quick_button_right")
-            ) { sharedPrefs: SharedPreferencesView, currentData: QuickButtonPreferences ->
-                val prefBuilder = currentData.toBuilder()
-                if (!currentData.hasLeftButton()) {
-                    prefBuilder.leftButton =
-                        QuickButtonPreferences.QuickButton.newBuilder().setIconId(
-                            sharedPrefs.getInt(
-                                "quick_button_left",
-                                QuickButtonPreferencesRepository.DEFAULT_ICON_LEFT
-                            )
-                        ).build()
-                }
-
-                if (!currentData.hasCenterButton()) {
-                    prefBuilder.centerButton =
-                        QuickButtonPreferences.QuickButton.newBuilder().setIconId(
-                            sharedPrefs.getInt(
-                                "quick_button_center",
-                                QuickButtonPreferencesRepository.DEFAULT_ICON_CENTER
-                            )
-                        ).build()
-                }
-                if (!currentData.hasRightButton()) {
-                    prefBuilder.rightButton =
-                        QuickButtonPreferences.QuickButton.newBuilder().setIconId(
-                            sharedPrefs.getInt(
-                                "quick_button_right",
-                                QuickButtonPreferencesRepository.DEFAULT_ICON_RIGHT
-                            )
-                        ).build()
-                }
-                prefBuilder.build()
-            }
-        )
-    }
+    produceMigrations = { context -> QuickButtonPreferencesMigrations().get(context) }
 )
 
 private val Context.unlauncherAppsStore: DataStore<UnlauncherApps> by dataStore(
@@ -77,5 +37,6 @@ class UnlauncherDataSource(context: Context, lifecycleScope: LifecycleCoroutineS
     val quickButtonPreferencesRepo =
         QuickButtonPreferencesRepository(context.quickButtonPreferencesStore, lifecycleScope)
     val unlauncherAppsRepo = UnlauncherAppsRepository(context.unlauncherAppsStore, lifecycleScope)
-    val corePreferencesRepo = CorePreferencesRepository(context.corePreferencesStore, lifecycleScope)
+    val corePreferencesRepo =
+        CorePreferencesRepository(context.corePreferencesStore, lifecycleScope)
 }

--- a/app/src/main/java/com/sduduzog/slimlauncher/datasource/quickbuttonprefs/QuickButtonPreferencesMigrations.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/datasource/quickbuttonprefs/QuickButtonPreferencesMigrations.kt
@@ -1,0 +1,81 @@
+package com.sduduzog.slimlauncher.datasource.quickbuttonprefs
+
+import android.content.Context
+import androidx.datastore.core.DataMigration
+import androidx.datastore.migrations.SharedPreferencesMigration
+import androidx.datastore.migrations.SharedPreferencesView
+import com.jkuester.unlauncher.datastore.QuickButtonPreferences
+
+class QuickButtonPreferencesMigrations {
+    fun get(context: Context): List<DataMigration<QuickButtonPreferences>> {
+        return listOf(
+            SharedPreferencesMigration(
+                context,
+                "settings",
+                setOf("quick_button_left", "quick_button_center", "quick_button_right")
+            ) { sharedPrefs: SharedPreferencesView, currentData: QuickButtonPreferences ->
+                val prefBuilder = currentData.toBuilder()
+                if (!currentData.hasLeftButton()) {
+                    prefBuilder.leftButton =
+                        QuickButtonPreferences.QuickButton.newBuilder().setIconId(
+                            sharedPrefs.getInt(
+                                "quick_button_left",
+                                QuickButtonPreferencesRepository.IC_CALL
+                            )
+                        ).build()
+                }
+
+                if (!currentData.hasCenterButton()) {
+                    prefBuilder.centerButton =
+                        QuickButtonPreferences.QuickButton.newBuilder().setIconId(
+                            sharedPrefs.getInt(
+                                "quick_button_center",
+                                QuickButtonPreferencesRepository.IC_COG
+                            )
+                        ).build()
+                }
+                if (!currentData.hasRightButton()) {
+                    prefBuilder.rightButton =
+                        QuickButtonPreferences.QuickButton.newBuilder().setIconId(
+                            sharedPrefs.getInt(
+                                "quick_button_right",
+                                QuickButtonPreferencesRepository.IC_PHOTO_CAMERA
+                            )
+                        ).build()
+                }
+                prefBuilder.build()
+            },
+            object : DataMigration<QuickButtonPreferences> {
+                override suspend fun shouldMigrate(currentData: QuickButtonPreferences): Boolean {
+                    return !QuickButtonPreferencesRepository.RES_BY_ICON.keys.containsAll(
+                        listOf(
+                            currentData.leftButton.iconId,
+                            currentData.centerButton.iconId,
+                            currentData.rightButton.iconId
+                        )
+                    )
+                }
+
+                override suspend fun migrate(currentData: QuickButtonPreferences): QuickButtonPreferences {
+                    val icons = QuickButtonPreferencesRepository.RES_BY_ICON.keys
+                    val prefBuilder = currentData.toBuilder()
+                    if (!icons.contains(currentData.leftButton.iconId)) {
+                        prefBuilder.leftButton = QuickButtonPreferences.QuickButton.newBuilder()
+                            .setIconId(QuickButtonPreferencesRepository.IC_CALL).build()
+                    }
+                    if (!icons.contains(currentData.centerButton.iconId)) {
+                        prefBuilder.centerButton = QuickButtonPreferences.QuickButton.newBuilder()
+                            .setIconId(QuickButtonPreferencesRepository.IC_COG).build()
+                    }
+                    if (!icons.contains(currentData.rightButton.iconId)) {
+                        prefBuilder.rightButton = QuickButtonPreferences.QuickButton.newBuilder()
+                            .setIconId(QuickButtonPreferencesRepository.IC_PHOTO_CAMERA).build()
+                    }
+                    return prefBuilder.build()
+                }
+
+                override suspend fun cleanUp() {}
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/sduduzog/slimlauncher/datasource/quickbuttonprefs/QuickButtonPreferencesRepository.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/datasource/quickbuttonprefs/QuickButtonPreferencesRepository.kt
@@ -10,7 +10,6 @@ import com.sduduzog.slimlauncher.R
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.transform
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import java.io.IOException
@@ -20,9 +19,16 @@ class QuickButtonPreferencesRepository(
     private val lifecycleScope: LifecycleCoroutineScope
 ) {
     companion object {
-        const val DEFAULT_ICON_LEFT = R.drawable.ic_call
-        const val DEFAULT_ICON_CENTER = R.drawable.ic_cog
-        const val DEFAULT_ICON_RIGHT = R.drawable.ic_photo_camera
+        const val IC_EMPTY = 1
+        const val IC_CALL = 2
+        const val IC_COG = 3
+        const val IC_PHOTO_CAMERA = 4
+        val RES_BY_ICON = mapOf(
+            IC_CALL to R.drawable.ic_call,
+            IC_COG to R.drawable.ic_cog,
+            IC_PHOTO_CAMERA to R.drawable.ic_photo_camera,
+            IC_EMPTY to R.drawable.ic_empty
+        )
     }
 
     private val quickButtonPreferencesFlow: Flow<QuickButtonPreferences> =
@@ -39,7 +45,6 @@ class QuickButtonPreferencesRepository(
                     throw exception
                 }
             }
-            .transform { prefs -> emit(validateQuickButtonPreferences(prefs)) }
 
     fun liveData(): LiveData<QuickButtonPreferences> {
         return quickButtonPreferencesFlow.asLiveData()
@@ -85,28 +90,5 @@ class QuickButtonPreferencesRepository(
                     .build()
             }
         }
-    }
-
-    private fun validateQuickButtonPreferences(prefs: QuickButtonPreferences): QuickButtonPreferences {
-        if (!prefs.hasLeftButton() || !prefs.hasCenterButton() || !prefs.hasRightButton()) {
-            val prefBuilder = prefs.toBuilder()
-            if (!prefs.hasLeftButton()) {
-                prefBuilder.leftButton =
-                    QuickButtonPreferences.QuickButton.newBuilder().setIconId(DEFAULT_ICON_LEFT)
-                        .build()
-            }
-            if (!prefs.hasCenterButton()) {
-                prefBuilder.centerButton =
-                    QuickButtonPreferences.QuickButton.newBuilder().setIconId(DEFAULT_ICON_CENTER)
-                        .build()
-            }
-            if (!prefs.hasRightButton()) {
-                prefBuilder.rightButton =
-                    QuickButtonPreferences.QuickButton.newBuilder().setIconId(DEFAULT_ICON_RIGHT)
-                        .build()
-            }
-            return prefBuilder.build()
-        }
-        return prefs
     }
 }

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/dialogs/ChooseQuickButtonDialog.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/dialogs/ChooseQuickButtonDialog.kt
@@ -13,7 +13,8 @@ class ChooseQuickButtonDialog(
     private val defaultIconId: Int
 ) : DialogFragment() {
     private var onDismissListener: DialogInterface.OnDismissListener? = null
-    private val iconIdsByIndex = mapOf(0 to defaultIconId, 1 to R.drawable.ic_empty)
+    private val iconIdsByIndex =
+        mapOf(0 to defaultIconId, 1 to QuickButtonPreferencesRepository.IC_EMPTY)
     private val indexesByIconId = iconIdsByIndex.entries.associate { it.value to it.key }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -22,11 +23,13 @@ class ChooseQuickButtonDialog(
         val quickButtonPrefs = repo.get()
         var currentIconId = 0
         when (defaultIconId) {
-            QuickButtonPreferencesRepository.DEFAULT_ICON_LEFT -> currentIconId =
+            QuickButtonPreferencesRepository.IC_CALL -> currentIconId =
                 quickButtonPrefs.leftButton.iconId
-            QuickButtonPreferencesRepository.DEFAULT_ICON_CENTER -> currentIconId =
+
+            QuickButtonPreferencesRepository.IC_COG -> currentIconId =
                 quickButtonPrefs.centerButton.iconId
-            QuickButtonPreferencesRepository.DEFAULT_ICON_RIGHT -> currentIconId =
+
+            QuickButtonPreferencesRepository.IC_PHOTO_CAMERA -> currentIconId =
                 quickButtonPrefs.rightButton.iconId
         }
 
@@ -38,13 +41,15 @@ class ChooseQuickButtonDialog(
         ) { dialogInterface, i ->
             dialogInterface.dismiss()
             when (defaultIconId) {
-                QuickButtonPreferencesRepository.DEFAULT_ICON_LEFT -> repo.updateLeftIconId(
+                QuickButtonPreferencesRepository.IC_CALL -> repo.updateLeftIconId(
                     iconIdsByIndex[i]!!
                 )
-                QuickButtonPreferencesRepository.DEFAULT_ICON_CENTER -> repo.updateCenterIconId(
+
+                QuickButtonPreferencesRepository.IC_COG -> repo.updateCenterIconId(
                     iconIdsByIndex[i]!!
                 )
-                QuickButtonPreferencesRepository.DEFAULT_ICON_RIGHT -> repo.updateRightIconId(
+
+                QuickButtonPreferencesRepository.IC_PHOTO_CAMERA -> repo.updateRightIconId(
                     iconIdsByIndex[i]!!
                 )
             }

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -23,6 +23,7 @@ import com.sduduzog.slimlauncher.R
 import com.sduduzog.slimlauncher.adapters.AppDrawerAdapter
 import com.sduduzog.slimlauncher.adapters.HomeAdapter
 import com.sduduzog.slimlauncher.datasource.UnlauncherDataSource
+import com.sduduzog.slimlauncher.datasource.quickbuttonprefs.QuickButtonPreferencesRepository
 import com.sduduzog.slimlauncher.models.HomeApp
 import com.sduduzog.slimlauncher.models.MainViewModel
 import com.sduduzog.slimlauncher.utils.BaseFragment
@@ -139,7 +140,7 @@ class HomeFragment : BaseFragment(), OnLaunchAppListener {
 
         unlauncherDataSource.quickButtonPreferencesRepo.liveData()
             .observe(viewLifecycleOwner) { prefs ->
-                val leftButtonIcon = prefs.leftButton.iconId
+                val leftButtonIcon = QuickButtonPreferencesRepository.RES_BY_ICON.getValue(prefs.leftButton.iconId)
                 home_fragment_call.setImageResource(leftButtonIcon)
                 if (leftButtonIcon != R.drawable.ic_empty) {
                     home_fragment_call.setOnClickListener { view ->
@@ -157,7 +158,7 @@ class HomeFragment : BaseFragment(), OnLaunchAppListener {
                     }
                 }
 
-                val centerButtonIcon = prefs.centerButton.iconId
+                val centerButtonIcon = QuickButtonPreferencesRepository.RES_BY_ICON.getValue(prefs.centerButton.iconId)
                 home_fragment_options.setImageResource(centerButtonIcon)
                 if (centerButtonIcon != R.drawable.ic_empty) {
                     home_fragment_options.setOnClickListener(
@@ -167,7 +168,7 @@ class HomeFragment : BaseFragment(), OnLaunchAppListener {
                     )
                 }
 
-                val rightButtonIcon = prefs.rightButton.iconId
+                val rightButtonIcon = QuickButtonPreferencesRepository.RES_BY_ICON.getValue(prefs.rightButton.iconId)
                 home_fragment_camera.setImageResource(rightButtonIcon)
                 if (rightButtonIcon != R.drawable.ic_empty) {
                     home_fragment_camera.setOnClickListener {

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/options/CustomizeQuickButtonsFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/options/CustomizeQuickButtonsFragment.kt
@@ -10,7 +10,10 @@ import com.sduduzog.slimlauncher.datasource.quickbuttonprefs.QuickButtonPreferen
 import com.sduduzog.slimlauncher.ui.dialogs.ChooseQuickButtonDialog
 import com.sduduzog.slimlauncher.utils.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.android.synthetic.main.customize_quick_buttons_fragment.*
+import kotlinx.android.synthetic.main.customize_quick_buttons_fragment.customize_quick_buttons_fragment
+import kotlinx.android.synthetic.main.customize_quick_buttons_fragment.customize_quick_buttons_fragment_center
+import kotlinx.android.synthetic.main.customize_quick_buttons_fragment.customize_quick_buttons_fragment_left
+import kotlinx.android.synthetic.main.customize_quick_buttons_fragment.customize_quick_buttons_fragment_right
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -30,28 +33,31 @@ class CustomizeQuickButtonsFragment : BaseFragment() {
         super.onViewCreated(view, savedInstanceState)
         val prefsRepo = unlauncherDataSource.quickButtonPreferencesRepo
 
-        prefsRepo.liveData().observe(viewLifecycleOwner, { prefs ->
-            customize_quick_buttons_fragment_left.setImageResource(prefs.leftButton.iconId)
-            customize_quick_buttons_fragment_center.setImageResource(prefs.centerButton.iconId)
-            customize_quick_buttons_fragment_right.setImageResource(prefs.rightButton.iconId)
-        })
+        prefsRepo.liveData().observe(viewLifecycleOwner) { prefs ->
+            customize_quick_buttons_fragment_left
+                .setImageResource(QuickButtonPreferencesRepository.RES_BY_ICON.getValue(prefs.leftButton.iconId))
+            customize_quick_buttons_fragment_center
+                .setImageResource(QuickButtonPreferencesRepository.RES_BY_ICON.getValue(prefs.centerButton.iconId))
+            customize_quick_buttons_fragment_right
+                .setImageResource(QuickButtonPreferencesRepository.RES_BY_ICON.getValue(prefs.rightButton.iconId))
+        }
 
         customize_quick_buttons_fragment_left.setOnClickListener {
             ChooseQuickButtonDialog(
                 prefsRepo,
-                QuickButtonPreferencesRepository.DEFAULT_ICON_LEFT
+                QuickButtonPreferencesRepository.IC_CALL
             ).showNow(childFragmentManager, "QUICK_BUTTON_CHOOSER")
         }
         customize_quick_buttons_fragment_center.setOnClickListener {
             ChooseQuickButtonDialog(
                 prefsRepo,
-                QuickButtonPreferencesRepository.DEFAULT_ICON_CENTER
+                QuickButtonPreferencesRepository.IC_COG
             ).showNow(childFragmentManager, "QUICK_BUTTON_CHOOSER")
         }
         customize_quick_buttons_fragment_right.setOnClickListener {
             ChooseQuickButtonDialog(
                 prefsRepo,
-                QuickButtonPreferencesRepository.DEFAULT_ICON_RIGHT
+                QuickButtonPreferencesRepository.IC_PHOTO_CAMERA
             ).showNow(childFragmentManager, "QUICK_BUTTON_CHOOSER")
         }
     }


### PR DESCRIPTION
The Quick Button preferences were storing the _Resource Id_ of the icon that should be shown.  Unfortunately, Android Resource Ids are not consistent between different versions of an app.  So, upgrading the app changes all the Resource Ids (and the stored preference values no longer mapped to actual resources).

I have updated the value stored for the preference to just be an arbitrary `Int` value that I have manually mapped to the various Icon resources.  This seems best because I can reuse the same proto data structure to store the preference, but it will also remain consistent between different versions of the app.

I have added a new migration for the Quick Button preferences that will set the default icon pref values for any of the quick buttons that is not currently associated with a valid icon.  This does two things. For anyone upgrading from `1.3.0`, this migration will reset their Quick Button preferences to the default values (unfortunately their custom Quick Button settings will not be recoverable).  This will prevent the app from crashing if someone upgrades after updating their Quick Buttons in `1.3.0`.  The second thing the migration does is simply provide default values for a new installation.  

Closes https://github.com/jkuester/unlauncher/issues/129