### PR TITLE
fix(#131): set proper system UI colors for status and nav bars

### DIFF
--- a/app/src/main/java/com/sduduzog/slimlauncher/MainActivity.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/MainActivity.kt
@@ -17,6 +17,7 @@ import androidx.navigation.Navigation.findNavController
 import com.sduduzog.slimlauncher.utils.*
 import dagger.hilt.android.AndroidEntryPoint
 import java.lang.reflect.Method
+import javax.inject.Inject
 import kotlin.math.absoluteValue
 
 
@@ -27,6 +28,8 @@ class MainActivity : AppCompatActivity(),
 
     private val wallpaperManager = WallpaperManager(this)
 
+    @Inject
+    lateinit var systemUiManager: SystemUiManager
     private lateinit var settings: SharedPreferences
     private lateinit var navigator: NavController
     private lateinit var homeWatcher: HomeWatcher
@@ -68,7 +71,7 @@ class MainActivity : AppCompatActivity(),
     override fun onResume() {
         super.onResume()
         overridePendingTransition(android.R.anim.fade_in, android.R.anim.fade_out)
-        toggleStatusBar()
+        systemUiManager.setSystemUiVisibility()
     }
 
     override fun onStart() {
@@ -88,7 +91,7 @@ class MainActivity : AppCompatActivity(),
 
     override fun onWindowFocusChanged(hasFocus: Boolean) {
         super.onWindowFocusChanged(hasFocus)
-        if (hasFocus) toggleStatusBar()
+        if (hasFocus) systemUiManager.setSystemUiVisibility()
     }
 
     override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences?, s: String?) {
@@ -96,7 +99,7 @@ class MainActivity : AppCompatActivity(),
             recreate()
         }
         if (s.equals(getString(R.string.prefs_settings_key_toggle_status_bar), true)) {
-            toggleStatusBar()
+            systemUiManager.setSystemUiVisibility()
         }
     }
 
@@ -123,24 +126,6 @@ class MainActivity : AppCompatActivity(),
     override fun onHomePressed() {
         dispatchHome()
         navigator.popBackStack(R.id.homeFragment, false)
-    }
-
-    private fun showSystemUI() {
-        window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_LAYOUT_STABLE)
-    }
-
-    private fun hideSystemUI() {
-        window.decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                or View.SYSTEM_UI_FLAG_FULLSCREEN)
-    }
-
-    private fun toggleStatusBar() {
-        val isHidden = settings.getBoolean(getString(R.string.prefs_settings_key_toggle_status_bar), false)
-        if (isHidden) {
-            hideSystemUI()
-        } else {
-            showSystemUI()
-        }
     }
 
     companion object {

--- a/app/src/main/java/com/sduduzog/slimlauncher/utils/BaseFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/utils/BaseFragment.kt
@@ -3,40 +3,26 @@ package com.sduduzog.slimlauncher.utils
 import android.content.Context
 import android.content.Intent
 import android.content.pm.LauncherApps
-import android.os.Build
 import android.os.Process
 import android.os.UserManager
-import android.util.TypedValue
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityOptionsCompat
 import androidx.fragment.app.Fragment
 import com.sduduzog.slimlauncher.BuildConfig
-import com.sduduzog.slimlauncher.R
 import com.sduduzog.slimlauncher.data.model.App
+import javax.inject.Inject
 
 abstract class BaseFragment : Fragment(), ISubscriber {
+    @Inject
+    lateinit var systemUiManager: SystemUiManager
+
     abstract fun getFragmentView(): ViewGroup
 
 
     override fun onResume() {
         super.onResume()
-        val settings = requireContext().getSharedPreferences(getString(R.string.prefs_settings), AppCompatActivity.MODE_PRIVATE)
-        val active = settings.getInt(getString(R.string.prefs_settings_key_theme), 0)
-
-
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            when (active) {
-                0, 3, 5 -> {
-                    val flags = requireActivity().window.decorView.systemUiVisibility or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-                    getFragmentView().systemUiVisibility = flags
-                }
-            }
-            val value = TypedValue()
-            requireContext().theme.resolveAttribute(R.attr.colorPrimary, value, true)
-            requireActivity().window.statusBarColor = value.data
-        }
+        systemUiManager.setSystemUiColors()
     }
 
     override fun onStart() {

--- a/app/src/main/java/com/sduduzog/slimlauncher/utils/SystemUiManager.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/utils/SystemUiManager.kt
@@ -44,7 +44,7 @@ open class SystemUiManager internal constructor(internal val context: Context) {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
                 return MSystemUiManager(context)
             }
-            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
                 return OSystemUiManager(context)
             }
             return SystemUiManager(context)

--- a/app/src/main/java/com/sduduzog/slimlauncher/utils/SystemUiManager.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/utils/SystemUiManager.kt
@@ -1,5 +1,6 @@
 package com.sduduzog.slimlauncher.utils
 
+import android.annotation.TargetApi
 import android.app.Activity
 import android.content.Context
 import android.content.SharedPreferences
@@ -8,59 +9,143 @@ import android.os.Build
 import android.util.TypedValue
 import android.view.View
 import android.view.Window
+import android.view.WindowInsets
+import android.view.WindowInsetsController
+import android.view.WindowManager
+import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import com.sduduzog.slimlauncher.R
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityComponent
 import dagger.hilt.android.qualifiers.ActivityContext
-import dagger.hilt.android.scopes.ActivityScoped
-import javax.inject.Inject
 
-@ActivityScoped
-class SystemUiManager @Inject constructor(@ActivityContext private val context: Context) {
-    private val window: Window = (context as Activity).window
-    private val settings: SharedPreferences = context.getSharedPreferences(
+@Module
+@InstallIn(ActivityComponent::class)
+open class SystemUiManager internal constructor(internal val context: Context) {
+    internal val window: Window = (context as Activity).window
+    internal val settings: SharedPreferences = context.getSharedPreferences(
         context.getString(R.string.prefs_settings),
         AppCompatActivity.MODE_PRIVATE
     )
 
-    fun setSystemUiVisibility() {
-        window.decorView.systemUiVisibility =
-            getLightUiBarFlags() or getToggleStatusBarFlags()
+    companion object {
+        @Provides
+        fun createInstance(@ActivityContext context: Context): SystemUiManager {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                (context as Activity).window.attributes.layoutInDisplayCutoutMode =
+                    WindowManager.LayoutParams.LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES
+            }
+
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+                return LSystemUiManager(context)
+            }
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+                return MSystemUiManager(context)
+            }
+            if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                return OSystemUiManager(context)
+            }
+            return SystemUiManager(context)
+        }
     }
 
-    fun setSystemUiColors() {
+    @TargetApi(Build.VERSION_CODES.R)
+    open fun setSystemUiVisibility() {
+        val insetsController = window.insetsController
+
+        if (isSystemUiHidden()) {
+            insetsController?.hide(WindowInsets.Type.statusBars())
+        } else {
+            insetsController?.show(WindowInsets.Type.statusBars())
+        }
+
+        if (isLightModeTheme()) {
+            insetsController?.setSystemBarsAppearance(
+                WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS,
+                WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
+            )
+            insetsController?.setSystemBarsAppearance(
+                WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS,
+                WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS
+            )
+        } else {
+            insetsController?.setSystemBarsAppearance(
+                0,
+                WindowInsetsController.APPEARANCE_LIGHT_STATUS_BARS
+            )
+            insetsController?.setSystemBarsAppearance(
+                0,
+                WindowInsetsController.APPEARANCE_LIGHT_NAVIGATION_BARS
+            )
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.O)
+    open fun setSystemUiColors() {
+        val primaryColor = getPrimaryColor()
+        window.statusBarColor = primaryColor
+        window.navigationBarColor = primaryColor
+    }
+
+    internal fun getPrimaryColor(): Int {
         val primaryColor = TypedValue()
         context.theme.resolveAttribute(R.attr.colorPrimary, primaryColor, true)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            window.statusBarColor = primaryColor.data
-        }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            window.navigationBarColor = primaryColor.data
-        }
+        return primaryColor.data
     }
 
-    private fun getToggleStatusBarFlags(): Int {
-        val isHidden = settings.getBoolean(
+    internal fun isSystemUiHidden(): Boolean {
+        return settings.getBoolean(
             context.getString(R.string.prefs_settings_key_toggle_status_bar),
             false
         )
-        return View.SYSTEM_UI_FLAG_LAYOUT_STABLE or if (isHidden) View.SYSTEM_UI_FLAG_FULLSCREEN else 0
     }
 
-    private fun getLightUiBarFlags(): Int {
+    internal fun isLightModeTheme(): Boolean {
         val theme = settings.getInt(context.getString(R.string.prefs_settings_key_theme), 0)
         val uiMode = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
-        var uiFlags = 0
-        if (listOf(
-                6, 3, 5
-            ).contains(theme) || (theme == 0 && uiMode == Configuration.UI_MODE_NIGHT_NO)
-        ) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                uiFlags = uiFlags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
-            }
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                uiFlags = uiFlags or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
-            }
+        return listOf(
+            6,
+            3,
+            5
+        ).contains(theme) || (theme == 0 && uiMode == Configuration.UI_MODE_NIGHT_NO)
+    }
+
+    private open class OSystemUiManager(context: Context) : SystemUiManager(context) {
+        @RequiresApi(Build.VERSION_CODES.O)
+        override fun setSystemUiVisibility() {
+            window.decorView.systemUiVisibility =
+                getLightUiBarFlags() or getToggleStatusBarFlags()
         }
-        return uiFlags
+
+        @RequiresApi(Build.VERSION_CODES.O)
+        open fun getLightUiBarFlags(): Int {
+            return if (isLightModeTheme()) View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR else 0
+        }
+
+        private fun getToggleStatusBarFlags(): Int {
+            return View.SYSTEM_UI_FLAG_LAYOUT_STABLE or if (isSystemUiHidden()) View.SYSTEM_UI_FLAG_FULLSCREEN else 0
+        }
+    }
+
+    private open class MSystemUiManager(context: Context) : OSystemUiManager(context) {
+        @RequiresApi(Build.VERSION_CODES.M)
+        override fun setSystemUiColors() {
+            window.statusBarColor = getPrimaryColor()
+        }
+
+        @RequiresApi(Build.VERSION_CODES.M)
+        override fun getLightUiBarFlags(): Int {
+            return if (isLightModeTheme()) View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR else 0
+        }
+    }
+
+    private class LSystemUiManager(context: Context) : MSystemUiManager(context) {
+        override fun setSystemUiColors() {}
+
+        override fun getLightUiBarFlags(): Int {
+            return 0
+        }
     }
 }

--- a/app/src/main/java/com/sduduzog/slimlauncher/utils/SystemUiManager.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/utils/SystemUiManager.kt
@@ -1,0 +1,66 @@
+package com.sduduzog.slimlauncher.utils
+
+import android.app.Activity
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.res.Configuration
+import android.os.Build
+import android.util.TypedValue
+import android.view.View
+import android.view.Window
+import androidx.appcompat.app.AppCompatActivity
+import com.sduduzog.slimlauncher.R
+import dagger.hilt.android.qualifiers.ActivityContext
+import dagger.hilt.android.scopes.ActivityScoped
+import javax.inject.Inject
+
+@ActivityScoped
+class SystemUiManager @Inject constructor(@ActivityContext private val context: Context) {
+    private val window: Window = (context as Activity).window
+    private val settings: SharedPreferences = context.getSharedPreferences(
+        context.getString(R.string.prefs_settings),
+        AppCompatActivity.MODE_PRIVATE
+    )
+
+    fun setSystemUiVisibility() {
+        window.decorView.systemUiVisibility =
+            getLightUiBarFlags() or getToggleStatusBarFlags()
+    }
+
+    fun setSystemUiColors() {
+        val primaryColor = TypedValue()
+        context.theme.resolveAttribute(R.attr.colorPrimary, primaryColor, true)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            window.statusBarColor = primaryColor.data
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            window.navigationBarColor = primaryColor.data
+        }
+    }
+
+    private fun getToggleStatusBarFlags(): Int {
+        val isHidden = settings.getBoolean(
+            context.getString(R.string.prefs_settings_key_toggle_status_bar),
+            false
+        )
+        return View.SYSTEM_UI_FLAG_LAYOUT_STABLE or if (isHidden) View.SYSTEM_UI_FLAG_FULLSCREEN else 0
+    }
+
+    private fun getLightUiBarFlags(): Int {
+        val theme = settings.getInt(context.getString(R.string.prefs_settings_key_theme), 0)
+        val uiMode = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        var uiFlags = 0
+        if (listOf(
+                6, 3, 5
+            ).contains(theme) || (theme == 0 && uiMode == Configuration.UI_MODE_NIGHT_NO)
+        ) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                uiFlags = uiFlags or View.SYSTEM_UI_FLAG_LIGHT_STATUS_BAR
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                uiFlags = uiFlags or View.SYSTEM_UI_FLAG_LIGHT_NAVIGATION_BAR
+            }
+        }
+        return uiFlags
+    }
+}


### PR DESCRIPTION
Closes #131

The colors of the Navigation bar at the bottom of the screen have always just been left to the default (dark) system color. This looks fine for the dark themes, but as noted in the issue, it does not look great for the light themes.

@hayribakici set a good initial starting point in [this PR](https://github.com/jkuester/unlauncher/pull/132), but unfortunately, upon testing I found that modifying the theme resources was not going to work the best across a wide range of Android versions (or at least I could not figure it out).

That PR launched me down the rabbit-hole of trying to understand the right way to do this. I ended up finding layers of different support for various system APIs and functionality all for customizing the look of the status bar at the top and the navigation bar at the bottom. 

This PR adds a new `SystemUiManager` class that encapsulates all this logic and will use the proper functionality for the particular Android version the app is running on.  

I have tested on the following Android versions:

- `5` - No support for changing the status bar or navigation bar. Both just use the default (Dark) system coloring. Looks as good as it can given the circumstances (themes and hiding the status bar still work).
- `6` - Supports theming the status bar but not the navigation bar. Nav bar still just uses the default (Dark) system coloring.
- `10` - Supports theming both status bar and navigation bar (using the now-deprecated `systemUiVisibility` flags)
- `13` - Supports theming both status bar and navigation bar (using the new `WindowInsetsController`). I also think I fixed an existing bug in Android 13 around the handling of cutouts in the status bar.