### PR TITLE
Shows and hides keyboard when scrolling the app drawer

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
             android:screenOrientation="portrait"
             android:stateNotNeeded="true"
             tools:ignore="LockedOrientationActivity"
+            android:windowSoftInputMode="adjustNothing"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -5,11 +5,14 @@ import android.content.*
 import android.content.pm.LauncherApps
 import android.net.Uri
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import android.os.UserManager
 import android.provider.AlarmClock
 import android.provider.CalendarContract
 import android.provider.MediaStore
 import android.provider.Settings
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
@@ -19,6 +22,9 @@ import android.widget.PopupMenu
 import android.widget.Toast
 import androidx.constraintlayout.motion.widget.MotionLayout
 import androidx.constraintlayout.motion.widget.MotionLayout.TransitionListener
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsAnimationCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.Navigation
@@ -32,8 +38,11 @@ import com.sduduzog.slimlauncher.datasource.quickbuttonprefs.QuickButtonPreferen
 import com.sduduzog.slimlauncher.models.HomeApp
 import com.sduduzog.slimlauncher.models.MainViewModel
 import com.sduduzog.slimlauncher.ui.dialogs.RenameAppDisplayNameDialog
+import com.sduduzog.slimlauncher.utils.AppDrawerScrollListener
 import com.sduduzog.slimlauncher.utils.BaseFragment
 import com.sduduzog.slimlauncher.utils.OnLaunchAppListener
+import com.sduduzog.slimlauncher.utils.isKeyboardOpen
+import com.sduduzog.slimlauncher.utils.shouldOpenKeyboard
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.android.synthetic.main.home_fragment.*
 import kotlinx.coroutines.Dispatchers
@@ -53,6 +62,12 @@ class HomeFragment : BaseFragment(), OnLaunchAppListener {
 
     private lateinit var receiver: BroadcastReceiver
     private lateinit var appDrawerAdapter: AppDrawerAdapter
+    private lateinit var inputMethodManager: InputMethodManager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        inputMethodManager = requireContext().getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
+    }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View = inflater.inflate(R.layout.home_fragment, container, false)
 
@@ -192,9 +207,8 @@ class HomeFragment : BaseFragment(), OnLaunchAppListener {
         app_drawer_edit_text.addTextChangedListener(appDrawerAdapter.searchBoxListener)
 
         home_fragment.setTransitionListener(object : TransitionListener {
+            val handler = Handler(Looper.getMainLooper())
             override fun onTransitionCompleted(motionLayout: MotionLayout?, currentId: Int) {
-                val inputMethodManager = requireContext().getSystemService(Activity.INPUT_METHOD_SERVICE) as InputMethodManager
-
                 when (currentId) {
                     motionLayout?.startState -> {
                         // hide the keyboard and remove focus from the EditText when swiping back up
@@ -204,13 +218,17 @@ class HomeFragment : BaseFragment(), OnLaunchAppListener {
 
                     motionLayout?.endState -> {
                         // Check for preferences to open the keyboard
-                        if (unlauncherDataSource.corePreferencesRepo.get().activateKeyboardInDrawer) {
-                            app_drawer_edit_text.requestFocus()
-                            // show the keyboard and set focus to the EditText when swiping down
-                            inputMethodManager.showSoftInput(
-                                app_drawer_edit_text,
-                                InputMethodManager.SHOW_IMPLICIT
-                            )
+                        if (shouldOpenKeyboard(unlauncherDataSource)) {
+                            // in order to avoid UI Jank, we add the focus and showing the keyboard
+                            // in the back of the queue
+                            handler.post {
+                                app_drawer_edit_text.requestFocus()
+                                // show the keyboard and set focus to the EditText when swiping down
+                                inputMethodManager.showSoftInput(
+                                    app_drawer_edit_text,
+                                    InputMethodManager.SHOW_IMPLICIT
+                                )
+                            }
                         }
                     }
                 }
@@ -226,6 +244,25 @@ class HomeFragment : BaseFragment(), OnLaunchAppListener {
 
             override fun onTransitionChange(motionLayout: MotionLayout?, startId: Int, endId: Int, progress: Float) {
                 // do nothing
+            }
+        })
+
+        app_drawer_fragment_list.addOnScrollListener(object: AppDrawerScrollListener() {
+            override fun onScrolledUp() {
+                if (shouldOpenKeyboard(unlauncherDataSource) && !isKeyboardOpen(app_drawer_edit_text)) {
+                    // show the keyboard again when user is scrolling up
+                    inputMethodManager.showSoftInput(
+                        app_drawer_edit_text,
+                        InputMethodManager.SHOW_IMPLICIT
+                    )
+                }
+            }
+
+            override fun onScrolledDown() {
+                if (shouldOpenKeyboard(unlauncherDataSource) && isKeyboardOpen(app_drawer_edit_text)) {
+                    // hide the keyboard again when scrolling down
+                    inputMethodManager.hideSoftInputFromWindow(requireView().windowToken, 0)
+                }
             }
         })
     }

--- a/app/src/main/java/com/sduduzog/slimlauncher/utils/AppDrawerScrollListener.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/utils/AppDrawerScrollListener.kt
@@ -1,0 +1,30 @@
+package com.sduduzog.slimlauncher.utils
+
+import androidx.recyclerview.widget.RecyclerView
+
+abstract class AppDrawerScrollListener : RecyclerView.OnScrollListener() {
+
+    override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+        if (recyclerView.scrollState == RecyclerView.SCROLL_STATE_DRAGGING) {
+            if (dy > 0) {
+                // finger moves upwards
+                onScrolledDown()
+            } else if (dy < 0) {
+                // finger moves downwards
+                onScrolledUp()
+            }
+        }
+    }
+
+    /**
+     * Called when user is scrolling upward the [RecyclerView]
+     */
+    abstract fun onScrolledUp()
+
+    /**
+     * * Called when user is scrolling downward the [RecyclerView]
+     */
+    abstract fun onScrolledDown()
+
+
+}

--- a/app/src/main/java/com/sduduzog/slimlauncher/utils/Utils.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/utils/Utils.kt
@@ -8,7 +8,12 @@ import android.graphics.Insets
 import android.graphics.Rect
 import android.os.Build
 import android.util.DisplayMetrics
+import android.util.Log
+import android.view.View
 import android.view.WindowInsets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import com.sduduzog.slimlauncher.datasource.UnlauncherDataSource
 
 
 private fun isAppDefaultLauncher(context: Context?): Boolean {
@@ -70,4 +75,16 @@ fun getScreenHeight(activity: Activity): Int {
         activity.windowManager.defaultDisplay.getMetrics(outMetrics)
         outMetrics.heightPixels
     }
+}
+
+fun shouldOpenKeyboard(unlauncherDataSource: UnlauncherDataSource) : Boolean =
+        unlauncherDataSource.corePreferencesRepo.get().activateKeyboardInDrawer
+
+/**
+ * @return [true] when the keyboard is displayed.
+ * Works for android API [20] and higher
+ */
+fun isKeyboardOpen(view: View) : Boolean {
+    val insets = ViewCompat.getRootWindowInsets(view)
+    return insets?.isVisible(WindowInsetsCompat.Type.ime()) ?: false
 }


### PR DESCRIPTION
This PR is a UX enhancement when scrolling through the app drawer. 

If the show keyboard option is set, it will minimize the keyboard once users start scrolling down the app drawer. Vice versa, it displays the keyboard when the user is scrolling up again. 

[Screen_recording_20231021_132138.webm](https://github.com/jkuester/unlauncher/assets/3295340/b618dcc2-25de-4009-9c0a-1d5505aad7d5)

In order to be smooth, the `MainActivity`'s `android:windowSoftInputMode` had to be set to `adjustNothing`. This also conflicts with PR #143 , since it would cover the search field if it set to the bottom of the screen. There are fixes for this as seen in [an official android guide](https://developer.android.com/develop/ui/views/layout/sw-keyboard).
