### PR TITLE
feat(search): Prioritize apps starting with query

### DIFF
--- a/app/src/main/java/com/sduduzog/slimlauncher/adapters/AppDrawerAdapter.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/adapters/AppDrawerAdapter.kt
@@ -55,6 +55,10 @@ class AppDrawerAdapter(
         this.updateDisplayedApps()
     }
 
+    private fun onlyFirstStringStartsWith(first: String, second: String, query: String) : Boolean {
+        return first.startsWith(query, true) and !second.startsWith(query, true);
+    }
+    
     @SuppressLint("NotifyDataSetChanged")
     private fun updateDisplayedApps() {
         filteredApps = apps.filter { app ->
@@ -63,8 +67,8 @@ class AppDrawerAdapter(
             Comparator<UnlauncherApp>{
                 a, b -> when {
                     // if an app's name starts with the query prefer it
-                    a.displayName.startsWith(filterQuery) && ! b.displayName.startsWith(filterQuery) -> -1
-                    ! a.displayName.startsWith(filterQuery) && b.displayName.startsWith(filterQuery) -> 1
+                    onlyFirstStringStartsWith(a.displayName, b.displayName, filterQuery) -> -1
+                    onlyFirstStringStartsWith(b.displayName, a.displayName, filterQuery) -> 1
                     // if both or none start with the query sort in normal oder
                     a.displayName > b.displayName -> 1
                     a.displayName < b.displayName -> -1

--- a/app/src/main/java/com/sduduzog/slimlauncher/adapters/AppDrawerAdapter.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/adapters/AppDrawerAdapter.kt
@@ -59,7 +59,19 @@ class AppDrawerAdapter(
     private fun updateDisplayedApps() {
         filteredApps = apps.filter { app ->
             regex.replace(app.displayName, "").contains(filterQuery, ignoreCase = true)
-        }.toList()
+        }.toList().sortedWith(
+            Comparator<UnlauncherApp>{
+                a, b -> when {
+                    // if an app's name starts with the query prefer it
+                    a.displayName.startsWith(filterQuery) && ! b.displayName.startsWith(filterQuery) -> -1
+                    ! a.displayName.startsWith(filterQuery) && b.displayName.startsWith(filterQuery) -> 1
+                    // if both or none start with the query sort in normal oder
+                    a.displayName > b.displayName -> 1
+                    a.displayName < b.displayName -> -1
+                    else -> 0
+                }
+            }
+        )
         notifyDataSetChanged()
     }
 


### PR DESCRIPTION
When sorting apps during queries in the drawer place the apps whose name starts with the query first.

![Screenshot_20231029_104739x800](https://github.com/jkuester/unlauncher/assets/531760/814e707f-9742-4677-bca2-654ab24cdcf8)
