### PR TITLE
fix(options): use correct text color in options switches

### DIFF
--- a/app/src/main/res/layout/customize_app_drawer_fragment_search_field_options.xml
+++ b/app/src/main/res/layout/customize_app_drawer_fragment_search_field_options.xml
@@ -30,6 +30,7 @@
         android:text="@string/customize_app_drawer_fragment_show_search_bar"
         android:textAppearance="@style/TextAppearance.AppCompat"
         android:textSize="@dimen/_20ssp"
+        android:textColor="?switchTextColor"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
@@ -42,6 +43,7 @@
         android:text="@string/customize_app_drawer_fragment_open_keyboard"
         android:textAppearance="@style/TextAppearance.AppCompat"
         android:textSize="@dimen/_20ssp"
+        android:textColor="?switchTextColor"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/customize_app_drawer_fragment_search_field_position" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/customize_app_drawer_fragment_search_field_options.xml
+++ b/app/src/main/res/layout/customize_app_drawer_fragment_search_field_options.xml
@@ -56,6 +56,7 @@
         android:text="@string/customize_app_drawer_fragment_search_all"
         android:textAppearance="@style/TextAppearance.AppCompat"
         android:textSize="@dimen/font_size_customize_options"
+        android:textColor="?switchTextColor"
         app:layout_constraintTop_toBottomOf="@id/customize_app_drawer_open_keyboard_switch"
         app:layout_constraintStart_toStartOf="parent"/>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/options_fragment.xml
+++ b/app/src/main/res/layout/options_fragment.xml
@@ -140,6 +140,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="32dp"
+            android:textColor="?switchTextColor"
             android:text="@string/customize_app_drawer_fragment_auto_theme_wallpaper_text"
             android:textAppearance="@style/TextAppearance.AppCompat"
             android:textSize="@dimen/font_size_customize_options"


### PR DESCRIPTION
Adds correct `textColor` in `SwitchCompat` buttons.