### PR TITLE
fix(#190): hide uninstall option if app is system app.

### DIFF
--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -46,6 +46,7 @@ import com.sduduzog.slimlauncher.models.MainViewModel
 import com.sduduzog.slimlauncher.ui.dialogs.RenameAppDisplayNameDialog
 import com.sduduzog.slimlauncher.utils.BaseFragment
 import com.sduduzog.slimlauncher.utils.OnLaunchAppListener
+import com.sduduzog.slimlauncher.utils.isSystemApp
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.android.synthetic.main.home_fragment_content.app_drawer_edit_text
 import kotlinx.android.synthetic.main.home_fragment_content.app_drawer_fragment_list
@@ -377,6 +378,7 @@ class HomeFragment : BaseFragment(), OnLaunchAppListener {
         fun onAppLongClicked(app : UnlauncherApp, view: View) : Boolean {
             val popupMenu = PopupMenu(context, view)
             popupMenu.inflate(R.menu.app_long_press_menu)
+            hideUninstallOptionIfSystemApp(app, popupMenu)
 
             popupMenu.setOnMenuItemClickListener { item: MenuItem? ->
 
@@ -402,7 +404,6 @@ class HomeFragment : BaseFragment(), OnLaunchAppListener {
                         intent.data = Uri.parse("package:" + app.packageName)
                         uninstallAppLauncher.launch(intent)
                         //appDrawerAdapter.notifyDataSetChanged()
-                        // TODO: Handle the case when this is done for system apps
                     }
                 }
                 true
@@ -417,6 +418,15 @@ class HomeFragment : BaseFragment(), OnLaunchAppListener {
 
             popupMenu.show()
             return true
+        }
+
+        private fun hideUninstallOptionIfSystemApp(app:UnlauncherApp, popupMenu: PopupMenu) {
+            val pm = requireContext().packageManager
+            val info = pm.getApplicationInfo(app.packageName, 0)
+            if (info.isSystemApp()){
+                val uninstallMenuItem = popupMenu.menu.findItem(R.id.uninstall)
+                uninstallMenuItem.isVisible = false
+            }
         }
 
         fun onAppClicked(app: UnlauncherApp) {

--- a/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/ui/main/HomeFragment.kt
@@ -403,7 +403,6 @@ class HomeFragment : BaseFragment(), OnLaunchAppListener {
                         val intent = Intent(Intent.ACTION_DELETE)
                         intent.data = Uri.parse("package:" + app.packageName)
                         uninstallAppLauncher.launch(intent)
-                        //appDrawerAdapter.notifyDataSetChanged()
                     }
                 }
                 true

--- a/app/src/main/java/com/sduduzog/slimlauncher/utils/Utils.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/utils/Utils.kt
@@ -3,6 +3,7 @@ package com.sduduzog.slimlauncher.utils
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.content.pm.ApplicationInfo
 import android.content.res.Configuration
 import android.graphics.Insets
 import android.graphics.Rect
@@ -94,3 +95,6 @@ fun createTitleAndSubtitleText(context: Context, title: CharSequence, subtitle: 
 }
 
 fun String.firstUppercase() = this.first().uppercase()
+
+fun ApplicationInfo.isSystemApp(): Boolean = (this.flags and ApplicationInfo.FLAG_SYSTEM != 0) ||
+        (this.flags and ApplicationInfo.FLAG_UPDATED_SYSTEM_APP != 0)


### PR DESCRIPTION
This PR fixes #190 

I chose to just hide the uninstall option, because default launchers on android do the same. However, changing to put a notification instead should be doable with these given changes.