### PR TITLE
fix(#217): totally hide Analog Clock in drawer

### DIFF
--- a/app/src/main/res/xml/home_motion_scene.xml
+++ b/app/src/main/res/xml/home_motion_scene.xml
@@ -147,13 +147,12 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="0px"
-            android:alpha="0"
+            android:alpha="-1"
             app:visibilityMode="ignore"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintBottom_toTopOf="parent"
-            app:layout_constraintTop_toTopOf="parent"/>
+            app:layout_constraintBottom_toTopOf="parent" />
         <Constraint
             android:id="@+id/home_fragment_bin_time"
             android:layout_width="wrap_content"


### PR DESCRIPTION
Moves the clock completely off-screen.

Closes #217 