### PR TITLE
fix(#207): digital clock got line wrapped

### DIFF
--- a/app/src/main/res/layout/home_fragment_content.xml
+++ b/app/src/main/res/layout/home_fragment_content.xml
@@ -62,7 +62,7 @@
 
     <TextView
         android:id="@+id/home_fragment_time"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/_64sdp"
         android:text="@string/main_placeholder_clock"

--- a/app/src/main/res/xml/home_motion_scene_bottom.xml
+++ b/app/src/main/res/xml/home_motion_scene_bottom.xml
@@ -36,7 +36,7 @@
             app:layout_constraintTop_toTopOf="parent"/>
         <Constraint
             android:id="@+id/home_fragment_time"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_top_large"
             app:visibilityMode="ignore"
@@ -134,7 +134,7 @@
     <ConstraintSet android:id="@+id/home_motion_02">
         <Constraint
             android:id="@+id/home_fragment_time"
-            android:layout_width="wrap_content"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_top_large"
             android:alpha="-1"


### PR DESCRIPTION
Could not reproduce the problem and therefor not check whether the fix works as expected. It broadens clock's width to its parent's width.

Hopefully (hate to write it) that fixes the problem.