### PR TITLE
Revert "fix(#207): digital clock got line wrapped (#227)"

### DIFF
--- a/app/src/main/res/layout/home_fragment_content.xml
+++ b/app/src/main/res/layout/home_fragment_content.xml
@@ -62,7 +62,7 @@
 
     <TextView
         android:id="@+id/home_fragment_time"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/_64sdp"
         android:text="@string/main_placeholder_clock"

--- a/app/src/main/res/xml/home_motion_scene_bottom.xml
+++ b/app/src/main/res/xml/home_motion_scene_bottom.xml
@@ -36,7 +36,7 @@
             app:layout_constraintTop_toTopOf="parent"/>
         <Constraint
             android:id="@+id/home_fragment_time"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_top_large"
             app:visibilityMode="ignore"
@@ -134,7 +134,7 @@
     <ConstraintSet android:id="@+id/home_motion_02">
         <Constraint
             android:id="@+id/home_fragment_time"
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_top_large"
             android:alpha="-1"


### PR DESCRIPTION
This reverts commit 11cf002f4e38bae28af4739c63f3f5c50f08c6fd.

@khwolf, unfortunately I had to revert https://github.com/jkuester/unlauncher/pull/227.  I noticed later that for some reason, if you have the Search Field Position set to `Bottom`, then the alignment for the clock gets broken:

![image](https://github.com/jkuester/unlauncher/assets/8441903/94f12e3f-8377-4786-b018-5bddb7b7eb6a)
