### PR TITLE
Target Android 15

### DIFF
--- a/.github/workflows/android_branch_ci.yml
+++ b/.github/workflows/android_branch_ci.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up JDK 1.17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17

--- a/.github/workflows/android_master_ci.yml
+++ b/.github/workflows/android_master_ci.yml
@@ -29,7 +29,7 @@ jobs:
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
         env:
-          BUILD_TOOLS_VERSION: "34.0.0"
+          BUILD_TOOLS_VERSION: "35.0.0"
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/android_master_ci.yml
+++ b/.github/workflows/android_master_ci.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up JDK 1.17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17
@@ -31,7 +31,7 @@ jobs:
         env:
           BUILD_TOOLS_VERSION: "34.0.0"
       - name: Upload APK
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: app
           path: app/build/outputs/apk/release/com.jkuester.unlauncher-signed.apk

--- a/.github/workflows/android_pr_ci.yml
+++ b/.github/workflows/android_pr_ci.yml
@@ -12,16 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up JDK 1.17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17
       - name: Build with Gradle
         run: ./gradlew build
       - name: Upload APK
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: app
           path: app/build/outputs/apk/debug/com.jkuester.unlauncher.apk

--- a/.github/workflows/android_release_ci.yml
+++ b/.github/workflows/android_release_ci.yml
@@ -29,7 +29,7 @@ jobs:
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
         env:
-          BUILD_TOOLS_VERSION: "34.0.0"
+          BUILD_TOOLS_VERSION: "35.0.0"
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/android_release_ci.yml
+++ b/.github/workflows/android_release_ci.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up JDK 1.17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 17

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,11 +10,11 @@ plugins {
 }
 
 android {
-    compileSdk = 34
+    compileSdk = 35
     defaultConfig {
         applicationId = "com.jkuester.unlauncher"
         minSdk = 21
-        targetSdk = 34
+        targetSdk = 35
         versionName = "2.2.0-beta.1"
         versionCode = 22
         vectorDrawables { useSupportLibrary = true }


### PR DESCRIPTION
Also fixes CI by upgrading GitHub CI action versions.

So far, there is one known issue in Android 15: https://github.com/jkuester/unlauncher/issues/251

That issue will need to be addressed before these changes can be released, but I am going to merge this now to unblock other changes.