### PR TITLE
feat: Color previews when choosing themes

### DIFF
--- a/app/src/main/java/com/jkuester/unlauncher/dialog/ThemeColorPreviewDrawable.kt
+++ b/app/src/main/java/com/jkuester/unlauncher/dialog/ThemeColorPreviewDrawable.kt
@@ -1,0 +1,61 @@
+package com.jkuester.unlauncher.dialog
+
+import android.graphics.Canvas
+import android.graphics.ColorFilter
+import android.graphics.Paint
+import android.graphics.PixelFormat
+import android.graphics.drawable.Drawable
+import androidx.annotation.ColorInt
+
+class ThemeColorPreviewDrawable(
+    val sizePx: Int,
+    val strokeWidthPx: Float,
+    @ColorInt val bgColor: Int,
+    @ColorInt val headerColor: Int,
+    @ColorInt val fontColor: Int,
+    @ColorInt val strokeColor: Int
+) : Drawable() {
+
+    private val paint: Paint = Paint()
+    private val spacingPx: Int = (sizePx * 0.1f).toInt()
+
+    override fun draw(canvas: Canvas) {
+        val radius = sizePx / 2.toFloat()
+        drawCircleWithStroke(radius, radius, radius, bgColor, strokeColor, canvas)
+        drawCircleWithStroke(radius * 3 + spacingPx, radius, radius, headerColor, strokeColor, canvas)
+        drawCircleWithStroke(radius * 5 + spacingPx * 2, radius, radius, fontColor, strokeColor, canvas)
+    }
+
+    private fun drawCircleWithStroke(
+        cx: Float,
+        cy: Float,
+        radius: Float,
+        @ColorInt fillColor: Int,
+        @ColorInt strokeColor: Int,
+        canvas: Canvas
+    ) {
+        paint.style = Paint.Style.FILL
+        paint.color = fillColor
+        canvas.drawCircle(cx, cy, radius - strokeWidthPx / 2, paint)
+
+        paint.style = Paint.Style.STROKE
+        paint.strokeWidth = strokeWidthPx
+        paint.color = strokeColor
+        canvas.drawCircle(cx, cy, radius - strokeWidthPx / 2, paint)
+    }
+
+    override fun setAlpha(alpha: Int) {
+        paint.alpha = alpha
+    }
+
+    override fun setColorFilter(filter: ColorFilter?) {
+        paint.colorFilter = filter
+    }
+
+    @Deprecated("Deprecated in Java", ReplaceWith("PixelFormat.TRANSLUCENT", "android.graphics.PixelFormat"))
+    override fun getOpacity(): Int = PixelFormat.TRANSLUCENT
+
+    override fun getIntrinsicHeight(): Int = sizePx
+
+    override fun getIntrinsicWidth(): Int = 3 * sizePx + 2 * spacingPx
+}

--- a/app/src/main/java/com/jkuester/unlauncher/dialog/ThemeDialog.kt
+++ b/app/src/main/java/com/jkuester/unlauncher/dialog/ThemeDialog.kt
@@ -4,6 +4,15 @@ import android.app.AlertDialog
 import android.app.Dialog
 import android.content.DialogInterface
 import android.os.Bundle
+import android.text.SpannableStringBuilder
+import android.text.style.ImageSpan
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.RadioButton
+import androidx.annotation.ColorRes
+import androidx.core.text.set
+import androidx.core.text.toSpannable
 import androidx.fragment.app.DialogFragment
 import com.jkuester.unlauncher.datasource.DataRepository
 import com.jkuester.unlauncher.datasource.setTheme
@@ -11,6 +20,7 @@ import com.jkuester.unlauncher.datastore.proto.CorePreferences
 import com.jkuester.unlauncher.datastore.proto.Theme
 import com.jkuester.unlauncher.fragment.WithFragmentLifecycle
 import com.sduduzog.slimlauncher.R
+import com.sduduzog.slimlauncher.utils.getMyColor
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -19,17 +29,158 @@ class ThemeDialog : DialogFragment() {
     @Inject @WithFragmentLifecycle
     lateinit var corePreferencesRepo: DataRepository<CorePreferences>
 
-    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog = AlertDialog
-        .Builder(context)
-        .setTitle(R.string.choose_theme_dialog_title)
-        .setSingleChoiceItems(
-            R.array.themes_array,
-            corePreferencesRepo.get().theme.number,
-            this::onSelection
-        )
-        .create()
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val adapter = object : ArrayAdapter<CharSequence>(
+            requireContext(),
+            R.layout.adapter_item_theme,
+            resources.getTextArray(R.array.themes_array)
+        ) {
+
+            override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+                val radioButton = super.getView(position, convertView, parent) as RadioButton
+                // The 'system default' should not have any color previews
+                val themePreviewColors = getThemePreviewColors(position) ?: return radioButton
+                populateRadioButtonWithColorPreviews(radioButton, getItem(position), themePreviewColors)
+                return radioButton
+            }
+
+            private fun populateRadioButtonWithColorPreviews(
+                radioButton: RadioButton,
+                text: CharSequence?,
+                colors: Array<Int>
+            ) {
+                val textSize = radioButton.textSize.toInt()
+                val previewDrawable = ThemeColorPreviewDrawable(
+                    sizePx = textSize,
+                    strokeWidthPx = radioButton.context.resources.getDimension(R.dimen._1sdp),
+                    bgColor = context.getMyColor(colors[0]),
+                    headerColor = context.getMyColor(colors[1]),
+                    fontColor = context.getMyColor(colors[2]),
+                    strokeColor = context.getMyColor(R.color.colorGray)
+                )
+                previewDrawable.setBounds(
+                    0,
+                    0,
+                    previewDrawable.intrinsicWidth,
+                    previewDrawable.intrinsicHeight
+                )
+
+                val sSB = SpannableStringBuilder()
+                sSB.append(text).append(" ")
+                val start = sSB.length
+                sSB.append(" ")
+                sSB[start, start + 1] = ImageSpan(previewDrawable, ImageSpan.ALIGN_BOTTOM)
+
+                radioButton.text = sSB.toSpannable()
+            }
+        }
+
+        val al = AlertDialog
+            .Builder(context)
+            .setTitle(R.string.choose_theme_dialog_title)
+            .setSingleChoiceItems(
+                adapter,
+                corePreferencesRepo.get().theme.number,
+                this::onSelection
+            )
+            .create()
+
+        return al
+    }
 
     private fun onSelection(dialogInterface: DialogInterface, i: Int) = dialogInterface
         .dismiss()
         .also { corePreferencesRepo.updateAsync(setTheme(Theme.forNumber(i))) }
+
+    private fun getThemePreviewColors(listPosition: Int): Array<Int>? {
+        val colors = Array(3) { _ -> 0 }
+        when (listPosition) {
+            // System default
+            0 -> return null
+            // Midnight
+            1 -> {
+                fillArray(
+                    android.R.color.black,
+                    R.color.colorChineseWhite,
+                    R.color.colorChineseWhite,
+                    colors
+                )
+            }
+            // Jupiter
+            2 -> {
+                fillArray(
+                    R.color.colorBlueGrey,
+                    R.color.colorChineseWhite,
+                    R.color.colorGray,
+                    colors
+                )
+            }
+            // teal
+            3 -> {
+                fillArray(
+                    R.color.colorTeal,
+                    R.color.colorVampireBlack,
+                    R.color.colorGray,
+                    colors
+                )
+            }
+            // Candy
+            4 -> {
+                fillArray(
+                    R.color.colorCandy,
+                    R.color.colorChineseWhite,
+                    R.color.colorGray,
+                    colors
+                )
+            }
+            // Pastel
+            5 -> {
+                fillArray(
+                    R.color.colorPink,
+                    R.color.colorVampireBlack,
+                    R.color.colorGray,
+                    colors
+                )
+            }
+            // Noon
+            6 -> {
+                fillArray(
+                    android.R.color.white,
+                    R.color.colorVampireBlack,
+                    R.color.colorGray,
+                    colors
+                )
+            }
+            // Vlad
+            7 -> {
+                fillArray(
+                    R.color.colorGunmetal,
+                    R.color.colorDarkBlueGray,
+                    R.color.colorCultured,
+                    colors
+                )
+            }
+            // Groovy
+            8 -> {
+                fillArray(
+                    R.color.colorCharlestonGreen,
+                    R.color.colorAcidGreen,
+                    R.color.colorCookiesAndCream,
+                    colors
+                )
+            }
+        }
+        return colors
+    }
+
+    private fun fillArray(
+        @ColorRes bgColor: Int,
+        @ColorRes hdColor: Int,
+        @ColorRes fontColor: Int,
+        colors: Array<Int>
+    ) {
+        colors[0] = bgColor
+        colors[1] = hdColor
+        colors[2] = fontColor
+    }
 }

--- a/app/src/main/java/com/jkuester/unlauncher/dialog/ThemeDialog.kt
+++ b/app/src/main/java/com/jkuester/unlauncher/dialog/ThemeDialog.kt
@@ -94,11 +94,11 @@ class ThemeDialog : DialogFragment() {
 
     private fun getThemePreviewColors(listPosition: Int): Array<Int>? {
         val colors = Array(3) { _ -> 0 }
-        when (listPosition) {
+        when (Theme.forNumber(listPosition)) {
             // System default
-            0 -> return null
+            Theme.system_theme -> return null
             // Midnight
-            1 -> {
+            Theme.midnight -> {
                 fillArray(
                     android.R.color.black,
                     R.color.colorChineseWhite,
@@ -107,7 +107,7 @@ class ThemeDialog : DialogFragment() {
                 )
             }
             // Jupiter
-            2 -> {
+            Theme.jupiter -> {
                 fillArray(
                     R.color.colorBlueGrey,
                     R.color.colorChineseWhite,
@@ -116,7 +116,7 @@ class ThemeDialog : DialogFragment() {
                 )
             }
             // teal
-            3 -> {
+            Theme.teal -> {
                 fillArray(
                     R.color.colorTeal,
                     R.color.colorVampireBlack,
@@ -125,7 +125,7 @@ class ThemeDialog : DialogFragment() {
                 )
             }
             // Candy
-            4 -> {
+            Theme.candy -> {
                 fillArray(
                     R.color.colorCandy,
                     R.color.colorChineseWhite,
@@ -134,7 +134,7 @@ class ThemeDialog : DialogFragment() {
                 )
             }
             // Pastel
-            5 -> {
+            Theme.pastel -> {
                 fillArray(
                     R.color.colorPink,
                     R.color.colorVampireBlack,
@@ -143,7 +143,7 @@ class ThemeDialog : DialogFragment() {
                 )
             }
             // Noon
-            6 -> {
+            Theme.noon -> {
                 fillArray(
                     android.R.color.white,
                     R.color.colorVampireBlack,
@@ -152,7 +152,7 @@ class ThemeDialog : DialogFragment() {
                 )
             }
             // Vlad
-            7 -> {
+            Theme.vlad -> {
                 fillArray(
                     R.color.colorGunmetal,
                     R.color.colorDarkBlueGray,
@@ -161,7 +161,7 @@ class ThemeDialog : DialogFragment() {
                 )
             }
             // Groovy
-            8 -> {
+            Theme.groovy -> {
                 fillArray(
                     R.color.colorCharlestonGreen,
                     R.color.colorAcidGreen,
@@ -169,6 +169,7 @@ class ThemeDialog : DialogFragment() {
                     colors
                 )
             }
+            else -> return null
         }
         return colors
     }

--- a/app/src/main/java/com/jkuester/unlauncher/dialog/ThemeDialog.kt
+++ b/app/src/main/java/com/jkuester/unlauncher/dialog/ThemeDialog.kt
@@ -20,7 +20,7 @@ import com.jkuester.unlauncher.datastore.proto.CorePreferences
 import com.jkuester.unlauncher.datastore.proto.Theme
 import com.jkuester.unlauncher.fragment.WithFragmentLifecycle
 import com.sduduzog.slimlauncher.R
-import com.sduduzog.slimlauncher.utils.getMyColor
+import com.sduduzog.slimlauncher.utils.getColorCompat
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -53,10 +53,10 @@ class ThemeDialog : DialogFragment() {
                 val previewDrawable = ThemeColorPreviewDrawable(
                     sizePx = textSize,
                     strokeWidthPx = radioButton.context.resources.getDimension(R.dimen._1sdp),
-                    bgColor = context.getMyColor(colors[0]),
-                    headerColor = context.getMyColor(colors[1]),
-                    fontColor = context.getMyColor(colors[2]),
-                    strokeColor = context.getMyColor(R.color.colorGray)
+                    bgColor = context.getColorCompat(colors[0]),
+                    headerColor = context.getColorCompat(colors[1]),
+                    fontColor = context.getColorCompat(colors[2]),
+                    strokeColor = context.getColorCompat(R.color.colorGray)
                 )
                 previewDrawable.setBounds(
                     0,

--- a/app/src/main/java/com/sduduzog/slimlauncher/utils/Utils.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/utils/Utils.kt
@@ -48,10 +48,11 @@ fun AlignmentFormat.gravity(): Int = when (this.number) {
 }
 
 @ColorInt
-fun Context.getMyColor(@ColorRes colorId: Int): Int {
+fun Context.getColorCompat(@ColorRes colorId: Int): Int {
     return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        this.getColor(colorId)
+        this.resources.getColor(colorId, this.theme)
     } else {
+        @Suppress("DEPRECATION")
         this.resources.getColor(colorId)
     }
 }

--- a/app/src/main/java/com/sduduzog/slimlauncher/utils/Utils.kt
+++ b/app/src/main/java/com/sduduzog/slimlauncher/utils/Utils.kt
@@ -3,9 +3,12 @@ package com.sduduzog.slimlauncher.utils
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ApplicationInfo
+import android.os.Build
 import android.text.SpannableStringBuilder
 import android.text.Spanned
 import android.text.style.TextAppearanceSpan
+import androidx.annotation.ColorInt
+import androidx.annotation.ColorRes
 import com.jkuester.unlauncher.datastore.proto.AlignmentFormat
 import com.sduduzog.slimlauncher.R
 
@@ -42,4 +45,13 @@ fun AlignmentFormat.gravity(): Int = when (this.number) {
     2 -> 5 // RIGHT
     1 -> 1 // CENTER
     else -> 3 // LEFT
+}
+
+@ColorInt
+fun Context.getMyColor(@ColorRes colorId: Int): Int {
+    return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        this.getColor(colorId)
+    } else {
+        this.resources.getColor(colorId)
+    }
 }

--- a/app/src/main/res/layout/adapter_item_theme.xml
+++ b/app/src/main/res/layout/adapter_item_theme.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+
+    <RadioButton xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:clickable="false"
+        android:focusable="false"
+        android:focusableInTouchMode="false"
+        android:padding="@dimen/padding"
+        android:textAppearance="?android:attr/textAppearanceListItem"
+    />
+


### PR DESCRIPTION
With the increased amount of themes, choosing the right one is a matter of trying out multiple themes. This PR avoids that by showing a color preview of the current theme.

This however comes with certain **caveats**:

1. The colors of the previews are hand selected, meaning if another theme is added, representative colors must be selected (usually it is the `backgroundColor`, `headerColor` and `textEnabledColor`.
2. The order in which the themes are listed will be therefore 'cemented', meaning new themes are appended in the `R.array.adapter_item_theme` and in the new method `getThemePreviewColors()`

<img src="https://github.com/user-attachments/assets/7b8965f3-5f9d-46d6-a8fe-4d4436b80162" height="400px" />

<img src="https://github.com/user-attachments/assets/95fe1944-1ca1-45b1-9772-25d1d99babcf" height="400px" />

Overall, I am not 100% sure, if this approach also goes along with the slim design language of this launcher.
Furthermore, this PR has only been tested with Pixel 6a, Android 15.